### PR TITLE
Update keybind for Toggle Raycast Note

### DIFF
--- a/.github/workflows/playwright-iPad-Pro-11.yml
+++ b/.github/workflows/playwright-iPad-Pro-11.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
       - name: Set build name
-        run: echo "BUILD_NAME=iPad Pro 11" >> .env
+        run: echo "BUILD_NAME='iPad Pro 11'" >> .env
       - name: Playwright tests
         run: pnpm exec playwright test --project='iPad Pro 11'
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright-iPhone-14.yml
+++ b/.github/workflows/playwright-iPhone-14.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
       - name: Set build name
-        run: echo "BUILD_NAME=iPhone 14" >> .env
+        run: echo "BUILD_NAME='iPhone 14'" >> .env
       - name: Playwright tests
         run: pnpm exec playwright test --project='iPhone 14'
       - uses: actions/upload-artifact@v4

--- a/src/app/keybinds/page.tsx
+++ b/src/app/keybinds/page.tsx
@@ -25,7 +25,7 @@ const keybinds: KeybindsList = {
     'Search AI Commands': 'Option + O',
     'Define Word (Dictionary)': 'Option + E',
     'Search Quicklinks': 'Option + Q',
-    'Summarize Webpage (AI Command)': 'Option + W',
+    'Toggle Raycast Note': 'Option + W',
     'Summarize Youtube Video (AI Command)': 'Option + CMD + W',
     Confetti: 'Option + D',
   },

--- a/src/app/keybinds/page.tsx
+++ b/src/app/keybinds/page.tsx
@@ -23,10 +23,10 @@ const keybinds: KeybindsList = {
     'Search Bookmarks (Chrome)': 'Option + G',
     'Search Bookmarks (Raindrop)': 'Option + R',
     'Search AI Commands': 'Option + O',
-    'Define Word (Dictionary)': 'Option + E',
+    Dictionary: 'Option + E',
     'Search Quicklinks': 'Option + Q',
+    'Left Half(Window Management)': '^ + H',
     'Toggle Raycast Note': 'Option + W',
-    'Summarize Youtube Video (AI Command)': 'Option + CMD + W',
     Confetti: 'Option + D',
   },
   'Move Cursor': {


### PR DESCRIPTION
- Changed the keybind description from Summarize Webpage AI Command to Toggle Raycast Note for the shortcut Option  W in the keybinds list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new keybinds: 'Left Half (Window Management)' and 'Toggle Raycast Note'.
- **Changes**
  - Updated the label for 'Option + E' shortcut to 'Dictionary'.
  - Removed keybinds for 'Summarize Webpage (AI Command)' and 'Summarize Youtube Video (AI Command)'.
- **Chores**
  - Improved environment variable formatting in build workflows for iPad Pro 11 and iPhone 14.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->