### PR TITLE
Add conditional Argos upload based on GitHub actor

### DIFF
--- a/.github/workflows/playwright-chrome.yml
+++ b/.github/workflows/playwright-chrome.yml
@@ -25,6 +25,13 @@ jobs:
         run: pnpm exec playwright install --with-deps
       - name: Set build name
         run: echo "BUILD_NAME=Chrome" >> .env
+      - name: Set Argos upload flag based on actor
+        run: |
+          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            echo "UPLOAD_TO_ARGOS=false" >> .env
+          else
+            echo "UPLOAD_TO_ARGOS=true" >> .env
+          fi
       - name: Playwright tests
         run: pnpm exec playwright test --project='Chrome'
       - uses: actions/upload-artifact@v4
@@ -34,4 +41,5 @@ jobs:
           path: playwright-report/
           retention-days: 30
       - name: Upload screenshots to Argos
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: pnpm argos upload ./screenshots

--- a/.github/workflows/playwright-iPad-Pro-11.yml
+++ b/.github/workflows/playwright-iPad-Pro-11.yml
@@ -25,6 +25,13 @@ jobs:
         run: pnpm exec playwright install --with-deps
       - name: Set build name
         run: echo "BUILD_NAME='iPad Pro 11'" >> .env
+      - name: Set Argos upload flag based on actor
+        run: |
+          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            echo "UPLOAD_TO_ARGOS=false" >> .env
+          else
+            echo "UPLOAD_TO_ARGOS=true" >> .env
+          fi
       - name: Playwright tests
         run: pnpm exec playwright test --project='iPad Pro 11'
       - uses: actions/upload-artifact@v4
@@ -34,4 +41,5 @@ jobs:
           path: playwright-report/
           retention-days: 30
       - name: Upload screenshots to Argos
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: pnpm argos upload ./screenshots

--- a/.github/workflows/playwright-iPhone-14.yml
+++ b/.github/workflows/playwright-iPhone-14.yml
@@ -25,6 +25,13 @@ jobs:
         run: pnpm exec playwright install --with-deps
       - name: Set build name
         run: echo "BUILD_NAME='iPhone 14'" >> .env
+      - name: Set Argos upload flag based on actor
+        run: |
+          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            echo "UPLOAD_TO_ARGOS=false" >> .env
+          else
+            echo "UPLOAD_TO_ARGOS=true" >> .env
+          fi
       - name: Playwright tests
         run: pnpm exec playwright test --project='iPhone 14'
       - uses: actions/upload-artifact@v4
@@ -34,4 +41,5 @@ jobs:
           path: playwright-report/
           retention-days: 30
       - name: Upload screenshots to Argos
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: pnpm argos upload ./screenshots

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,7 +30,10 @@ export default defineConfig({
       '@argos-ci/playwright/reporter',
       {
         // Upload to Argos on CI only.
-        uploadToArgos: !!process.env.CI && !!process.env.BUILD_NAME,
+        uploadToArgos:
+          !!process.env.CI &&
+          !!process.env.BUILD_NAME &&
+          process.env.UPLOAD_TO_ARGOS !== 'false',
         buildName: process.env.BUILD_NAME || 'BUILD_NAME is empty',
       },
     ],


### PR DESCRIPTION
- Updated GitHub Actions workflows for Playwright tests on Chrome iPad Pro 11 and iPhone 14 to set an Argos upload flag based on the GitHub actor. -

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated automated workflows to control screenshot uploads based on the GitHub actor, preventing uploads when triggered by certain bots.
	- Enhanced environment variable handling to allow more flexible control over screenshot upload behavior during automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->