### PR TITLE
Update GitHub Actions to skip Argos upload for merged pull requests

### DIFF
--- a/.github/workflows/playwright-chrome.yml
+++ b/.github/workflows/playwright-chrome.yml
@@ -27,7 +27,7 @@ jobs:
         run: echo "BUILD_NAME=Chrome" >> .env
       - name: Set Argos upload flag based on actor
         run: |
-          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+          if [[ "${{ github.actor }}" == "dependabot[bot]" || "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
             echo "UPLOAD_TO_ARGOS=false" >> .env
           else
             echo "UPLOAD_TO_ARGOS=true" >> .env
@@ -41,5 +41,5 @@ jobs:
           path: playwright-report/
           retention-days: 30
       - name: Upload screenshots to Argos
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' && !(github.event_name == 'pull_request' && github.event.pull_request.merged == true) }}
         run: pnpm argos upload ./screenshots

--- a/.github/workflows/playwright-iPad-Pro-11.yml
+++ b/.github/workflows/playwright-iPad-Pro-11.yml
@@ -27,7 +27,7 @@ jobs:
         run: echo "BUILD_NAME='iPad Pro 11'" >> .env
       - name: Set Argos upload flag based on actor
         run: |
-          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+          if [[ "${{ github.actor }}" == "dependabot[bot]" || "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
             echo "UPLOAD_TO_ARGOS=false" >> .env
           else
             echo "UPLOAD_TO_ARGOS=true" >> .env
@@ -41,5 +41,5 @@ jobs:
           path: playwright-report/
           retention-days: 30
       - name: Upload screenshots to Argos
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' && !(github.event_name == 'pull_request' && github.event.pull_request.merged == true) }}
         run: pnpm argos upload ./screenshots

--- a/.github/workflows/playwright-iPhone-14.yml
+++ b/.github/workflows/playwright-iPhone-14.yml
@@ -27,7 +27,7 @@ jobs:
         run: echo "BUILD_NAME='iPhone 14'" >> .env
       - name: Set Argos upload flag based on actor
         run: |
-          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+          if [[ "${{ github.actor }}" == "dependabot[bot]" || "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
             echo "UPLOAD_TO_ARGOS=false" >> .env
           else
             echo "UPLOAD_TO_ARGOS=true" >> .env
@@ -41,5 +41,5 @@ jobs:
           path: playwright-report/
           retention-days: 30
       - name: Upload screenshots to Argos
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' && !(github.event_name == 'pull_request' && github.event.pull_request.merged == true) }}
         run: pnpm argos upload ./screenshots


### PR DESCRIPTION
- Modified workflows for Playwright Chrome iPad Pro 11 and iPhone 14 to include a condition that prevents Argos uploads when the event is a merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow logic to prevent screenshot uploads for merged pull requests and automated bot runs, ensuring screenshots are only uploaded for relevant events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->