### PR TITLE
Add module type to package.json and update Playwright config

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "laststance.io",
   "author": "Ryota Murakami <dojce1048@gmail.com> (https://github.com/ryota-murakami)",
   "private": true,
+  "type": "module",
   "engines": {
     "node": "22.x"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ import { defineConfig, devices } from '@playwright/test'
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-require('dotenv').config()
+import 'dotenv/config'
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -18,9 +18,9 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 1 : 0,
+  retries: 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : 10,
+  workers: process.env.CI ? 1 : 6,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['list'],


### PR DESCRIPTION
- Set type to module in package.json to enable ES module support.
- Updated Playwright configuration to use ES module import for dotenv.
- Changed retry count to 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated module system to use ECMAScript modules (ESM) by default.
  - Simplified environment variable loading for tests.
  - Disabled test retries across all environments.
  - Reduced the number of parallel test workers for local runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->