### PR TITLE
fix: enable full-page Playwright screenshots by removing height constraints

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,11 +37,11 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className="h-full antialiased" suppressHydrationWarning>
+    <html lang="en" className="antialiased" suppressHydrationWarning>
       <head>
         <meta name="view-transition" content="same-origin" />
       </head>
-      <body className="flex h-full bg-zinc-50 dark:bg-black">
+      <body className="flex min-h-full bg-zinc-50 dark:bg-black">
         <ProvidersClient>
           <div className="flex w-full">
             <Layout>{children}</Layout>


### PR DESCRIPTION
## Summary
Fixes Playwright full-page screenshots that were only capturing viewport content instead of the entire scrollable page.

## Root Cause
The `h-full` (height: 100%) classes on `<html>` and `<body>` tags were constraining the page height to exactly the viewport height. This prevented Playwright's `fullPage` screenshot option from capturing content beyond the visible viewport.

### Before
- Screenshot showed only ~2 items from Hardware section
- Remaining content (Development tools, Utility sections) appeared as white space
- Screenshot height was limited to viewport height despite `fullPage: true`

### After
- Screenshot captures all content sections:
  - ✅ Hardware section (5 items)
  - ✅ Development tools section (7 items)
  - ✅ Utility section (2 items)
  - ✅ Footer
- Full scrollable page height is properly captured

## Changes
```diff
- <html lang="en" className="h-full antialiased" suppressHydrationWarning>
+ <html lang="en" className="antialiased" suppressHydrationWarning>

- <body className="flex h-full bg-zinc-50 dark:bg-black">
+ <body className="flex min-h-full bg-zinc-50 dark:bg-black">
```

## Technical Details
- **Removed** `h-full` from `<html>` tag → allows natural document height
- **Changed** `h-full` to `min-h-full` on `<body>` tag → maintains minimum viewport height while allowing content expansion

## Testing
- ✅ All E2E tests pass (Chrome, iPad Pro landscape/portrait, iPhone 14)
- ✅ Verified full-page screenshots capture complete content
- ✅ No regression in existing visual tests
- ✅ Layout and styling remain unchanged

## Files Changed
- `src/app/layout.tsx`

## Impact
- **Scope**: Layout root only
- **Risk**: Low - minimal change to CSS classes
- **Behavior**: No visual changes to live site, only affects screenshot capture