### PR TITLE
fix(ci): resolve ESLint missing eslint-import-resolver-typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "baseline-browser-mapping": "^2.10.16",
     "code-inspector-plugin": "^1.5.1",
     "eslint": "^10.2.0",
+    "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-config-ts-prefixer": "^4.2.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-storybook": "10.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,9 @@ importers:
       eslint-config-ts-prefixer:
         specifier: ^4.2.0
         version: 4.2.0(@typescript-eslint/utils@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
+      eslint-import-resolver-typescript:
+        specifier: ^4.4.4
+        version: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@10.2.0(jiti@2.6.1))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI `pnpm lint` failed because `eslint.config.js` imports `createTypeScriptImportResolver` from `eslint-import-resolver-typescript`, but that package was only a transitive dependency of `eslint-config-ts-prefixer`. Under pnpm it was not linked at the project root, so Node raised `ERR_MODULE_NOT_FOUND` when loading the flat config.

## Changes

- Add `eslint-import-resolver-typescript` as a direct `devDependency` (aligned with the version already resolved via ts-prefixer).

## Testing

- `pnpm install`
- `pnpm lint` (passes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b84ddc1b-2627-4090-a40f-5ce1cf6d9692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b84ddc1b-2627-4090-a40f-5ce1cf6d9692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->