### PR TITLE
fix(articles): prevent unstable_cache from poisoning homepage article list

### DIFF
--- a/src/app/api/revalidate-articles/route.ts
+++ b/src/app/api/revalidate-articles/route.ts
@@ -1,0 +1,33 @@
+import { revalidateTag } from 'next/cache'
+import { NextResponse, type NextRequest } from 'next/server'
+
+import { env } from '@/env.mjs'
+
+/**
+ * One-shot revalidation endpoint for flushing the `all-articles` cache tag.
+ * Used to recover from a poisoned `unstable_cache` entry in Vercel's Data
+ * Cache (e.g., after a serverless runtime cached an empty article list).
+ *
+ * Guarded by `REVALIDATE_SECRET` env var. Returns 401 if the secret is not
+ * configured or the provided token does not match.
+ *
+ * @example
+ * // After deploy, run once:
+ * curl -X POST "https://laststance.io/api/revalidate-articles?secret=$REVALIDATE_SECRET"
+ * // => { "revalidated": true, "tag": "all-articles", "now": 1776239999999 }
+ */
+export async function POST(request: NextRequest) {
+  const secret = request.nextUrl.searchParams.get('secret')
+
+  if (!env.REVALIDATE_SECRET || secret !== env.REVALIDATE_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  revalidateTag('all-articles', 'max')
+
+  return NextResponse.json({
+    revalidated: true,
+    tag: 'all-articles',
+    now: Date.now(),
+  })
+}

--- a/src/app/articles/OSS-Feed-2026-04-11/page.tsx
+++ b/src/app/articles/OSS-Feed-2026-04-11/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+
 import Content, { article } from './content.mdx'
 
 export const metadata: Metadata = {

--- a/src/app/articles/OSS-Feed-2026-04-12/page.tsx
+++ b/src/app/articles/OSS-Feed-2026-04-12/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+
 import Content, { article } from './content.mdx'
 
 export const metadata: Metadata = {

--- a/src/app/articles/OSS-Feed-2026-04-13/page.tsx
+++ b/src/app/articles/OSS-Feed-2026-04-13/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+
 import Content, { article } from './content.mdx'
 
 export const metadata: Metadata = {

--- a/src/app/articles/OSS-Feed-2026-04-15/page.tsx
+++ b/src/app/articles/OSS-Feed-2026-04-15/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+
 import Content, { article } from './content.mdx'
 
 export const metadata: Metadata = {

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -4,6 +4,7 @@ import { z } from 'zod'
 export const env = createEnv({
   server: {
     PERSONAL_ACCESS_TOKEN: z.string().min(1).startsWith('ghp_').optional(),
+    REVALIDATE_SECRET: z.string().min(16).optional(),
   },
 
   client: {
@@ -13,6 +14,7 @@ export const env = createEnv({
   runtimeEnv: {
     PERSONAL_ACCESS_TOKEN: process.env.PERSONAL_ACCESS_TOKEN,
     NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
+    REVALIDATE_SECRET: process.env.REVALIDATE_SECRET,
   },
 
   skipValidation:

--- a/src/lib/articles.test.ts
+++ b/src/lib/articles.test.ts
@@ -57,14 +57,13 @@ describe('articles', () => {
       })
     })
 
-    it('should handle empty article list', async () => {
+    it('should throw on empty article list to prevent cache poisoning', async () => {
       const glob = await import('fast-glob')
       vi.mocked(glob.default).mockResolvedValue([])
 
-      const articles = await getAllArticles()
-
-      expect(articles).toHaveLength(0)
-      expect(articles).toEqual([])
+      await expect(getAllArticles()).rejects.toThrow(
+        'getAllArticles: glob returned no MDX files',
+      )
     })
 
     // TODO: Fix dynamic import mocking for vitest 4.0
@@ -82,7 +81,7 @@ describe('articles', () => {
       const mockGlob = vi.mocked(glob.default)
       mockGlob.mockResolvedValue([])
 
-      await getAllArticles()
+      await expect(getAllArticles()).rejects.toThrow()
 
       expect(mockGlob).toHaveBeenCalledWith('*/content.mdx', {
         cwd: path.resolve(process.cwd(), 'src/app/articles'),

--- a/src/lib/articles.ts
+++ b/src/lib/articles.ts
@@ -37,6 +37,11 @@ async function importArticle(
  * Wrapped with unstable_cache so the glob result persists across ISR
  * revalidations on Vercel, where source .mdx files may not exist in
  * the serverless function's compiled output.
+ *
+ * Throws if the glob returns empty — prevents cache poisoning when
+ * the serverless runtime can't access MDX files. `revalidate: 3600`
+ * floor ensures stale entries (e.g., added articles) refresh hourly
+ * instead of living forever under the default 1-year TTL.
  * @returns Sorted array of articles (newest first)
  * @example
  * const articles = await getAllArticles()
@@ -48,10 +53,16 @@ export const getAllArticles = unstable_cache(
       cwd: path.join(__dirname, '../app/articles'),
     })
 
+    if (articleFilenames.length === 0) {
+      throw new Error(
+        'getAllArticles: glob returned no MDX files — refusing to cache empty result',
+      )
+    }
+
     const articles = await Promise.all(articleFilenames.map(importArticle))
 
     return articles.sort((a, z) => +new Date(z.date) - +new Date(a.date))
   },
   ['all-articles'],
-  { tags: ['all-articles'] },
+  { tags: ['all-articles'], revalidate: 3600 },
 )


### PR DESCRIPTION
## Summary

- Root cause: `unstable_cache` in `src/lib/articles.ts` had no `revalidate` option → Next.js defaulted to a **1-year TTL**. Once an ISR revalidation ran in a serverless context where MDX files weren't bundled, `glob` returned `[]`, the empty array got cached, and every subsequent revalidation of `/` served `[]` forever.
- This is the 4th recurrence of the homepage-empty bug. Previous fixes (absolute path, ISR revalidate, Suspense) addressed symptoms around it but never this cache-poisoning path.
- `/articles` stayed correct because it's fully static (no `revalidate`) and thus never regenerated after build; only `/` with `revalidate = 3600` was vulnerable.

### Changes
- `src/lib/articles.ts` — add `revalidate: 3600` to `unstable_cache` options as a TTL floor; throw when `glob` returns zero files so `[]` can never be cached.
- `src/app/api/revalidate-articles/route.ts` (new) — secret-guarded `POST` endpoint that calls `revalidateTag('all-articles', 'max')` to flush the already-poisoned Data Cache entry once after deploy.
- `src/env.mjs` — add optional `REVALIDATE_SECRET` (min 16 chars).

### Verification
Locally reproduced the exact failure: pre-fix build produced `/` HTML with 4 stale articles (newest: `OSS-Feed-2026-04-07`) because `.next/cache/fetch-cache/2bb56c4d…` contained 38 articles with `revalidate: 31536000` from Apr 7. After deleting the cache file and rebuilding, `/` HTML correctly shows the 4 newest (`2026-04-15, 04-13, 04-12, 04-11`) and the cache entry regenerated with all 43 articles.

## Test plan

- [ ] `pnpm build` succeeds with no type errors
- [ ] Fresh `/` prerender contains `OSS-Feed-2026-04-15` and the 3 next-newest article links
- [ ] Set `REVALIDATE_SECRET` (≥16 chars) in Vercel production env
- [ ] After deploy, run `curl -X POST "https://laststance.io/api/revalidate-articles?secret=\$REVALIDATE_SECRET"` — expect `{ "revalidated": true, "tag": "all-articles", ... }`
- [ ] Without secret: `curl -X POST https://laststance.io/api/revalidate-articles` returns `401`
- [ ] Hard-refresh `https://laststance.io/` — homepage shows today's articles
- [ ] Verify `/articles` still lists all 43 articles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented on-demand article cache revalidation endpoint with secret-based authorization controls.
  * Updated article caching strategy with automatic hourly revalidation instead of default behavior.
  * Added validation to prevent empty article lists from being cached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->