### PR TITLE
feat(articles): paginate index to fix iPhone 14 screenshot limit

### DIFF
--- a/e2e/articles.spec.ts
+++ b/e2e/articles.spec.ts
@@ -4,14 +4,8 @@ import { test } from '@playwright/test'
 test('/articles', async ({ page }, testInfo) => {
   await page.goto('/articles')
 
-  // iPhone 14 stacks all 55+ articles vertically; a full-page screenshot
-  // exceeds Playwright's 32767px dimension limit, so capture the viewport only.
-  // Chrome / iPad Pro use the md grid layout and stay well under the limit.
-  const isNarrowMobile = testInfo.project.name === 'iPhone 14'
-
   await argosScreenshot(
     page,
     `[${testInfo.project.name}] https://laststance.io/articles`,
-    { fullPage: !isNarrowMobile },
   )
 })

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "next-themes": "^0.4.6",
     "nextjs-toploader": "^3.9.17",
     "node-html-parser": "^7.1.0",
+    "nuqs": "^2.8.9",
     "octokit": "^5.0.5",
     "react": "19.2.6",
     "react-dom": "19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       node-html-parser:
         specifier: ^7.1.0
         version: 7.1.0
+      nuqs:
+        specifier: ^2.8.9
+        version: 2.8.9(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       octokit:
         specifier: ^5.0.5
         version: 5.0.5
@@ -2011,6 +2014,9 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       webpack: '>=5.0.0'
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -4928,6 +4934,27 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nuqs@2.8.9:
+    resolution: {integrity: sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC1fF6CEJv3Fwm6eoZmfVPALB+vw8Udo7KL5uy96PFcYe1BIQ==}
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^5 || ^6 || ^7
+      react-router-dom: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
+        optional: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -8048,6 +8075,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -11442,6 +11471,13 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  nuqs@2.8.9(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      react: 19.2.6
+    optionalDependencies:
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   object-assign@4.1.1: {}
 

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,4 +1,5 @@
 import { type Metadata } from 'next'
+import { type SearchParams } from 'nuqs/server'
 
 import {
   Card,
@@ -7,10 +8,14 @@ import {
   CardDescription,
   CardCta,
 } from '@/components/Card'
+import { Pagination } from '@/components/Pagination'
 import { SimpleLayout } from '@/components/SimpleLayout'
 import { Box, VStack } from '@/components/ui/primitives'
 import { type ArticleWithSlug, getAllArticles } from '@/lib/articles'
+import { ARTICLES_PER_PAGE } from '@/lib/constants'
 import { formatDate } from '@/lib/formatDate'
+
+import { loadArticlesSearchParams } from './searchParams'
 
 const title = 'Articles'
 export const metadata: Metadata = {
@@ -22,6 +27,7 @@ export const metadata: Metadata = {
     images: [`/api/og?title=${title}`],
   },
 }
+
 function Article({ article }: { article: ArticleWithSlug }) {
   return (
     <article className="md:grid md:grid-cols-4 md:items-baseline">
@@ -51,8 +57,27 @@ function Article({ article }: { article: ArticleWithSlug }) {
   )
 }
 
-export default async function ArticlesIndex() {
+interface ArticlesIndexProps {
+  // Next.js 16 App Router exposes searchParams as a Promise.
+  searchParams: Promise<SearchParams>
+}
+
+export default async function ArticlesIndex({
+  searchParams,
+}: ArticlesIndexProps) {
+  const { page: requestedPage } = await loadArticlesSearchParams(searchParams)
   const articles = await getAllArticles()
+
+  // Clamp the requested page to the valid range so /articles?page=999 still
+  // renders the last available page instead of an empty list or 404.
+  const totalPages = Math.max(1, Math.ceil(articles.length / ARTICLES_PER_PAGE))
+  const currentPage = Math.min(Math.max(1, requestedPage), totalPages)
+
+  const startIndex = (currentPage - 1) * ARTICLES_PER_PAGE
+  const paginatedArticles = articles.slice(
+    startIndex,
+    startIndex + ARTICLES_PER_PAGE,
+  )
 
   return (
     <SimpleLayout
@@ -60,11 +85,18 @@ export default async function ArticlesIndex() {
       intro={`In particular, I often write about React, CSS, JavaScript, TypeScript,and Node.js. collected in chronological order.`}
     >
       <Box className="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40">
-        <VStack gap={16} className="max-w-3xl">
-          {articles.map((article) => (
-            <Article key={article.slug} article={article} />
-          ))}
-        </VStack>
+        <Box className="max-w-3xl">
+          <VStack gap={16}>
+            {paginatedArticles.map((article) => (
+              <Article key={article.slug} article={article} />
+            ))}
+          </VStack>
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            basePath="/articles"
+          />
+        </Box>
       </Box>
     </SimpleLayout>
   )

--- a/src/app/articles/searchParams.ts
+++ b/src/app/articles/searchParams.ts
@@ -1,0 +1,15 @@
+import { createLoader, parseAsInteger } from 'nuqs/server'
+
+/**
+ * Search-params schema for /articles.
+ * `page` is 1-indexed; nuqs falls back to 1 when missing or unparseable.
+ * @example
+ * // /articles → { page: 1 }
+ * // /articles?page=3 → { page: 3 }
+ * // /articles?page=abc → { page: 1 } (falls back to default)
+ */
+export const articlesSearchParams = {
+  page: parseAsInteger.withDefault(1),
+}
+
+export const loadArticlesSearchParams = createLoader(articlesSearchParams)

--- a/src/app/providers.client.tsx
+++ b/src/app/providers.client.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from 'next/navigation'
 import { ThemeProvider, useTheme } from 'next-themes'
 import NextTopLoader from 'nextjs-toploader'
+import { NuqsAdapter } from 'nuqs/adapters/next/app'
 import { createContext, useEffect } from 'react'
 
 import { usePrevious } from '@/hooks/usePrevious'
@@ -50,7 +51,7 @@ export function ProvidersClient({ children }: { children: React.ReactNode }) {
       />
       <ThemeProvider attribute="class" disableTransitionOnChange>
         <ThemeWatcher />
-        {children}
+        <NuqsAdapter>{children}</NuqsAdapter>
       </ThemeProvider>
     </AppContext.Provider>
   )

--- a/src/components/Pagination.test.tsx
+++ b/src/components/Pagination.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+
+import { buildPageList } from './Pagination'
+
+// 📄 buildPageList — pure ellipsis-list logic for Pagination.
+// Hard-coded expected values (DAMP) so each scenario reads as a complete spec.
+describe('buildPageList', () => {
+  it('returns every page directly when totalPages ≤ 7 (no ellipsis needed)', () => {
+    // Arrange — 5 pages comfortably fits without collapsing.
+    const currentPage = 2
+    const totalPages = 5
+
+    // Act
+    const pages = buildPageList(currentPage, totalPages)
+
+    // Assert
+    expect(pages).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('returns [1..7] when totalPages equals the threshold of 7', () => {
+    // Arrange — boundary: exactly 7 still skips ellipsis.
+    const currentPage = 3
+    const totalPages = 7
+
+    // Act
+    const pages = buildPageList(currentPage, totalPages)
+
+    // Assert
+    expect(pages).toEqual([1, 2, 3, 4, 5, 6, 7])
+  })
+
+  it('places only a trailing ellipsis when current is near the start', () => {
+    // Arrange — page 1 of 10: window is [1, 2], so collapse pages 3-9.
+    const currentPage = 1
+    const totalPages = 10
+
+    // Act
+    const pages = buildPageList(currentPage, totalPages)
+
+    // Assert
+    expect(pages).toEqual([1, 2, 'ellipsis', 10])
+  })
+
+  it('shows both ellipses with window around current in the middle of the range', () => {
+    // Arrange — page 4 of 10: window is [3, 5], collapse pages 2 and 6-9.
+    const currentPage = 4
+    const totalPages = 10
+
+    // Act
+    const pages = buildPageList(currentPage, totalPages)
+
+    // Assert
+    expect(pages).toEqual([1, 'ellipsis', 3, 4, 5, 'ellipsis', 10])
+  })
+
+  it('places only a leading ellipsis when current is on the last page', () => {
+    // Arrange — page 10 of 10: window is [9, 9], collapse pages 2-8.
+    const currentPage = 10
+    const totalPages = 10
+
+    // Act
+    const pages = buildPageList(currentPage, totalPages)
+
+    // Assert
+    expect(pages).toEqual([1, 'ellipsis', 9, 10])
+  })
+
+  it('returns a single-entry list when totalPages is 1', () => {
+    // Arrange — edge case: nothing to paginate.
+    const currentPage = 1
+    const totalPages = 1
+
+    // Act
+    const pages = buildPageList(currentPage, totalPages)
+
+    // Assert
+    expect(pages).toEqual([1])
+  })
+})

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,171 @@
+import Link from 'next/link'
+
+import { cn } from '@/lib/utils'
+
+interface PaginationProps {
+  /** 1-indexed current page */
+  currentPage: number
+  /** Total number of pages (>= 1) */
+  totalPages: number
+  /** Base href without query string, e.g. "/articles" */
+  basePath: string
+}
+
+/**
+ * 📄 Pagination
+ * Server-component pagination control with Prev/Next + numbered page links.
+ * Renders as `<nav>` for accessibility. Page 1 omits the `?page=` query so
+ * the canonical /articles URL stays clean and dedupes with search-engine indexes.
+ * Compact numbered list with ellipsis (1 … 4 5 6 … 12) keeps mobile widths short.
+ * @example
+ * <Pagination currentPage={2} totalPages={6} basePath="/articles" />
+ */
+export function Pagination({
+  currentPage,
+  totalPages,
+  basePath,
+}: PaginationProps) {
+  // Only one page total → nothing to navigate, skip rendering.
+  if (totalPages <= 1) return null
+
+  const pages = buildPageList(currentPage, totalPages)
+  const prevPage = currentPage - 1
+  const nextPage = currentPage + 1
+  const isFirstPage = currentPage <= 1
+  const isLastPage = currentPage >= totalPages
+
+  return (
+    <nav
+      aria-label="Pagination"
+      className="mt-12 flex items-center justify-center gap-1 sm:gap-2"
+    >
+      <PaginationItem
+        href={hrefForPage(basePath, prevPage)}
+        disabled={isFirstPage}
+        ariaLabel="Go to previous page"
+        rel="prev"
+      >
+        <span aria-hidden="true">←</span>
+        <span className="sr-only sm:not-sr-only sm:ml-1">Previous</span>
+      </PaginationItem>
+      {pages.map((entry, index) =>
+        entry === 'ellipsis' ? (
+          <span
+            key={`ellipsis-${index}`}
+            aria-hidden="true"
+            className="px-2 text-sm text-zinc-400 dark:text-zinc-500"
+          >
+            …
+          </span>
+        ) : (
+          <PaginationItem
+            key={entry}
+            href={hrefForPage(basePath, entry)}
+            current={entry === currentPage}
+            ariaLabel={`Go to page ${entry}`}
+          >
+            {entry}
+          </PaginationItem>
+        ),
+      )}
+      <PaginationItem
+        href={hrefForPage(basePath, nextPage)}
+        disabled={isLastPage}
+        ariaLabel="Go to next page"
+        rel="next"
+      >
+        <span className="sr-only sm:not-sr-only sm:mr-1">Next</span>
+        <span aria-hidden="true">→</span>
+      </PaginationItem>
+    </nav>
+  )
+}
+
+interface PaginationItemProps {
+  href: string
+  children: React.ReactNode
+  current?: boolean
+  disabled?: boolean
+  ariaLabel: string
+  rel?: 'prev' | 'next'
+}
+
+// Single link or disabled placeholder. Kept local since the shape is specific
+// to this pagination control (current/disabled styling differs from buttons).
+function PaginationItem({
+  href,
+  children,
+  current = false,
+  disabled = false,
+  ariaLabel,
+  rel,
+}: PaginationItemProps) {
+  const className = cn(
+    'inline-flex h-9 min-w-9 items-center justify-center rounded-md px-3 text-sm font-medium transition-colors',
+    current
+      ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900'
+      : 'text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800',
+    disabled && 'pointer-events-none opacity-40',
+  )
+
+  if (disabled) {
+    return (
+      <span aria-hidden="true" className={className}>
+        {children}
+      </span>
+    )
+  }
+
+  return (
+    <Link
+      href={href}
+      aria-label={ariaLabel}
+      aria-current={current ? 'page' : undefined}
+      rel={rel}
+      className={className}
+    >
+      {children}
+    </Link>
+  )
+}
+
+// Page 1 keeps the canonical "/articles" path (no ?page=1) for SEO cleanliness.
+function hrefForPage(basePath: string, page: number): string {
+  return page <= 1 ? basePath : `${basePath}?page=${page}`
+}
+
+/**
+ * Build the visible page-number list with ellipsis markers.
+ * Always shows first / last / current ± 1; collapses the rest to `'ellipsis'`.
+ * @returns Array of page numbers and ellipsis markers in display order.
+ * @example
+ * buildPageList(2, 5)   // => [1, 2, 3, 4, 5]               (small set — no ellipsis)
+ * buildPageList(1, 10)  // => [1, 2, 'ellipsis', 10]        (near start — trailing ellipsis only)
+ * buildPageList(4, 10)  // => [1, 'ellipsis', 3, 4, 5, 'ellipsis', 10] (middle — both ellipses)
+ * buildPageList(10, 10) // => [1, 'ellipsis', 9, 10]        (near end — leading ellipsis only)
+ */
+type PageEntry = number | 'ellipsis'
+export function buildPageList(
+  currentPage: number,
+  totalPages: number,
+): PageEntry[] {
+  // Small page counts render every page directly — no ellipsis needed.
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1)
+  }
+
+  const entries: PageEntry[] = [1]
+  const windowStart = Math.max(2, currentPage - 1)
+  const windowEnd = Math.min(totalPages - 1, currentPage + 1)
+
+  if (windowStart > 2) entries.push('ellipsis')
+
+  for (let page = windowStart; page <= windowEnd; page++) {
+    entries.push(page)
+  }
+
+  if (windowEnd < totalPages - 1) entries.push('ellipsis')
+
+  entries.push(totalPages)
+  return entries
+}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -101,7 +101,8 @@ function PaginationItem({
   rel,
 }: PaginationItemProps) {
   const className = cn(
-    'inline-flex h-9 min-w-9 items-center justify-center rounded-md px-3 text-sm font-medium transition-colors',
+    // モバイル(< sm)は 44×44px (WCAG/HIG タップターゲット最小)、sm 以上は 36px に絞ってデスクトップでの主張を抑える
+    'inline-flex h-11 min-w-11 items-center justify-center rounded-md px-3 text-sm font-medium transition-colors sm:h-9 sm:min-w-9',
     current
       ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900'
       : 'text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Number of articles rendered per page on the /articles index.
+ * Sized so iPhone 14 (390px viewport) stays well under Playwright's
+ * 32767px screenshot dimension limit even as the archive grows.
+ */
+export const ARTICLES_PER_PAGE = 10

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,13 @@ export default defineConfig({
     // Define projects for workspace configuration (replaces vitest.workspace.ts)
     projects: [
       {
+        // Per-project resolve so the `@` alias works inside the workspace —
+        // top-level `resolve.alias` does not propagate into project contexts.
+        resolve: {
+          alias: {
+            '@': path.resolve(__dirname, './src'),
+          },
+        },
         test: {
           name: 'unit',
           environment: 'happy-dom',


### PR DESCRIPTION
## Summary
- `/articles` をページネーション化（10件/ページ）し、iPhone 14 E2E スクリーンショットが Playwright の 32767px 上限を超える根本原因を解消 🩹
- nuqs (`createLoader` + `parseAsInteger.withDefault(1)`) で型安全な `?page=N` クエリパラメータを実装。App Router 用 `NuqsAdapter` をプロバイダに追加
- ページ1は `?page=` を省略してカノニカル URL を保持し SEO 重複を回避。範囲外の値は最終ページにクランプ、不正値はページ1にフォールバック
- 純粋関数 `buildPageList` を抽出して 6 件の DAMP/AAA ユニットテストを追加（small/start/middle/end/boundary/single）
- Vitest workspace で `@/` エイリアスが解決されないバグを per-project `resolve.alias` で修正
- `e2e/articles.spec.ts` から `fullPage: false` ワークアラウンドを削除（不要になったため）

## Why
従来は記事54件を1ページに全表示しており、iPhone 14 (390×844) のフルページスクリーンショットが縦 32767px を超えてしまい Playwright が失敗していた。前回のコミット (3c36853) は `fullPage: false` で症状だけ隠していたが、ページネーション導入で根本解決。

## Test plan
- [x] `pnpm build` — `/articles` は `ƒ` Dynamic として正しくビルドされる
- [x] `pnpm test` — 166 件すべて green（`buildPageList` の 6 件追加分含む）
- [x] `pnpm playwright e2e/articles.spec.ts` — iPhone 14 スクリーンショット成功
- [x] `pnpm lint` / typecheck — clean
- [x] エッジケース手動確認（curl）：
  - `/articles` → ページ1（10件、`?page=` なし）
  - `/articles?page=2` → ページ2（10件）
  - `/articles?page=6` → 最終ページ（4件）
  - `/articles?page=999` → ページ6にクランプ
  - `/articles?page=abc` → ページ1にフォールバック
  - `/articles?page=-5` → ページ1にフォールバック

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Articles page now supports pagination with URL-based navigation and a compact pagination UI for navigating and sharing page-specific links.

* **Tests**
  * Added comprehensive unit tests covering pagination list generation and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/laststance.io/pull/1633)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->