### PR TITLE
feat(projects): split featured/archive with status labels

### DIFF
--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -26,10 +26,10 @@ test('featured Skills Desktop renders with Active status label', async ({
     skillsDesktopCard.locator('a[href="https://skills-desktop.vercel.app/"]'),
   ).toHaveAttribute('target', '_blank')
   // Status label is rendered "Active" but transformed to "ACTIVE" via Tailwind `uppercase`.
-  // Use hasText match to assert the underlying word regardless of CSS transform.
-  await expect(skillsDesktopCard.getByText('Active', { exact: true })).toHaveCount(
-    1,
-  )
+  // The label is duplicated in DOM (desktop block + mobile-expansion block) so we
+  // assert containment rather than count — the spec is "status text is wired to this card",
+  // not "rendered exactly once".
+  await expect(skillsDesktopCard).toContainText('Active')
 })
 
 test('featured electron-mcp-server renders with Experiment status label', async ({
@@ -44,10 +44,9 @@ test('featured electron-mcp-server renders with Experiment status label', async 
   })
 
   // Assert: present + EXPERIMENT label (uppercase via CSS).
+  // Same desktop/mobile DOM-duplication caveat as the Active-label test above.
   await expect(electronMcpCard).toBeVisible()
-  await expect(
-    electronMcpCard.getByText('Experiment', { exact: true }),
-  ).toHaveCount(1)
+  await expect(electronMcpCard).toContainText('Experiment')
 })
 
 test('archive Clean URL renders with Chrome Extension category', async ({

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -9,72 +9,92 @@ test('/projects', async ({ page }, testInfo) => {
   )
 })
 
-test('Clean URL project should be displayed correctly', async ({ page }) => {
-  await page.goto('/projects')
-
-  // Find the Clean URL project card (article element with h2 title)
-  const cleanUrlCard = page.locator('article').filter({
-    has: page.locator('h2', { hasText: 'Clean URL' }),
-  })
-
-  // Check that the card exists
-  await expect(cleanUrlCard).toBeVisible()
-
-  // Check the project title (h2 in minimal list layout)
-  await expect(cleanUrlCard.locator('h2')).toHaveText('Clean URL')
-
-  // The link wraps the entire card content
-  const link = cleanUrlCard.locator(
-    'a[href="https://chromewebstore.google.com/detail/clean-url/konddpmmdjghlicegcfdjehalocbkmpl"]',
-  )
-  await expect(link).toBeVisible()
-  await expect(link).toHaveAttribute('target', '_blank')
-
-  // Check that the Chrome logo is displayed
-  const logo = cleanUrlCard.locator('img').first()
-  await expect(logo).toBeVisible()
-})
-
-test('Coffee Timer project should be displayed correctly', async ({ page }) => {
-  await page.goto('/projects')
-
-  // Find the Coffee Timer project card (article element with h2 title)
-  const coffeeTimerCard = page.locator('article').filter({
-    has: page.locator('h2', { hasText: 'Coffee Timer' }),
-  })
-
-  // Check that the card exists
-  await expect(coffeeTimerCard).toBeVisible()
-
-  // Check the project title (h2 in minimal list layout)
-  await expect(coffeeTimerCard.locator('h2')).toHaveText('Coffee Timer')
-
-  // The link wraps the entire card content
-  const link = coffeeTimerCard.locator(
-    'a[href="https://github.com/laststance/coffee-timer"]',
-  )
-  await expect(link).toBeVisible()
-  await expect(link).toHaveAttribute('target', '_blank')
-
-  // Check that the Next.js logo is displayed
-  const logo = coffeeTimerCard.locator('img').first()
-  await expect(logo).toBeVisible()
-})
-
-test('Projects list should contain Clean URL and Coffee Timer', async ({
+test('featured Skills Desktop renders with Active status label', async ({
   page,
 }) => {
+  // Arrange
   await page.goto('/projects')
 
-  // Wait for the page to fully load and the project list to be rendered
-  // Project names are in h2 inside article elements (minimal list layout)
-  await page.waitForSelector('article h2', { state: 'visible' })
+  // Act: featured projects render inside <article> with h2 headings.
+  const skillsDesktopCard = page.locator('article').filter({
+    has: page.locator('h2', { hasText: 'Skills Desktop' }),
+  })
 
-  // Get all project titles (h2 elements inside articles)
-  const projectTitles = await page.locator('article h2').allTextContents()
+  // Assert: card is present, links externally, and shows ACTIVE status (uppercase via CSS).
+  await expect(skillsDesktopCard).toBeVisible()
+  await expect(
+    skillsDesktopCard.locator('a[href="https://skills-desktop.vercel.app/"]'),
+  ).toHaveAttribute('target', '_blank')
+  // Status label is rendered "Active" but transformed to "ACTIVE" via Tailwind `uppercase`.
+  // Use hasText match to assert the underlying word regardless of CSS transform.
+  await expect(skillsDesktopCard.getByText('Active', { exact: true })).toHaveCount(
+    1,
+  )
+})
 
-  // Check that Clean URL exists in the list (position-independent)
-  expect(projectTitles).toContain('Clean URL')
-  // Check that Coffee Timer exists in the list
-  expect(projectTitles).toContain('Coffee Timer')
+test('featured electron-mcp-server renders with Experiment status label', async ({
+  page,
+}) => {
+  // Arrange
+  await page.goto('/projects')
+
+  // Act
+  const electronMcpCard = page.locator('article').filter({
+    has: page.locator('h2', { hasText: 'electron-mcp-server' }),
+  })
+
+  // Assert: present + EXPERIMENT label (uppercase via CSS).
+  await expect(electronMcpCard).toBeVisible()
+  await expect(
+    electronMcpCard.getByText('Experiment', { exact: true }),
+  ).toHaveCount(1)
+})
+
+test('archive Clean URL renders with Chrome Extension category', async ({
+  page,
+}) => {
+  // Arrange
+  await page.goto('/projects')
+
+  // Act: archive items render as <li> inside the archive <ul>.
+  const cleanUrlLink = page.locator(
+    'a[href="https://chromewebstore.google.com/detail/clean-url/konddpmmdjghlicegcfdjehalocbkmpl"]',
+  )
+
+  // Assert: link is present, external, and shows the category.
+  await expect(cleanUrlLink).toBeVisible()
+  await expect(cleanUrlLink).toHaveAttribute('target', '_blank')
+  await expect(cleanUrlLink).toContainText('Clean URL')
+  await expect(cleanUrlLink).toContainText(/chrome extension/i)
+})
+
+test('archive Coffee Timer renders with Web App category', async ({ page }) => {
+  // Arrange
+  await page.goto('/projects')
+
+  // Act
+  const coffeeTimerLink = page.locator(
+    'a[href="https://github.com/laststance/coffee-timer"]',
+  )
+
+  // Assert
+  await expect(coffeeTimerLink).toBeVisible()
+  await expect(coffeeTimerLink).toHaveAttribute('target', '_blank')
+  await expect(coffeeTimerLink).toContainText('Coffee Timer')
+  await expect(coffeeTimerLink).toContainText(/web app/i)
+})
+
+test('featured section shows 7 projects and archive section shows 22', async ({
+  page,
+}) => {
+  // Arrange
+  await page.goto('/projects')
+
+  // Act: featured cards are <article>; archive items are <li> inside the archive list.
+  const featuredCards = page.locator('section[aria-label="Featured projects"] article')
+  const archiveItems = page.locator('section[aria-label="Archive projects"] li')
+
+  // Assert: structural counts catch accidental featured ↔ archive misplacement.
+  await expect(featuredCards).toHaveCount(7)
+  await expect(archiveItems).toHaveCount(22)
 })

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,23 +1,10 @@
 import { type Metadata } from 'next'
-import { type StaticImageData } from 'next/image'
 
+import { ArchiveProjectListItem } from '@/components/ArchiveProjectListItem'
 import { Container } from '@/components/Container'
-import { ProjectListItem } from '@/components/ProjectListItem'
+import { FeaturedProjectListItem } from '@/components/FeaturedProjectListItem'
 import { Box, Text } from '@/components/ui/primitives'
-import chromeLogo from '@/images/logos/icons8-chrome-48.png'
-import electronLogo from '@/images/logos/icons8-electron-48.png'
-import git from '@/images/logos/icons8-git-48.png'
-import macosLogo from '@/images/logos/icons8-macos-48.png'
-import nextLogo from '@/images/logos/icons8-nextjs-48.png'
-import npmLogo from '@/images/logos/icons8-npm-48.png'
-import reactLogo from '@/images/logos/icons8-react-a-javascript-library-for-building-user-interfaces-32.png'
-import reduxLogo from '@/images/logos/icons8-redux-48.png'
-import shellLogo from '@/images/logos/icons8-shell-40.png'
-import storybookLogo from '@/images/logos/icons8-storybook-48.png'
-import tailwindLogo from '@/images/logos/icons8-tailwindcss-48.png'
-import viteLogo from '@/images/logos/icons8-vite-48.png'
-import vscodeLogo from '@/images/logos/icons8-vscode-48.png'
-import mcpLogo from '@/images/logos/mcp.svg'
+import { ARCHIVE_PROJECTS, FEATURED_PROJECTS } from '@/lib/projects'
 
 const title = 'Projects'
 
@@ -32,289 +19,19 @@ export const metadata: Metadata = {
 }
 
 /**
- * Project data structure for the minimal list layout
- */
-type Project = {
-  name: string
-  description: string
-  category: string
-  href: string
-  logo: StaticImageData
-  featured?: boolean
-}
-
-/**
- * Flattened project list, sorted by importance (featured first)
- */
-const projects: Project[] = [
-  // Featured Projects
-  {
-    name: 'Skills Desktop',
-    description:
-      'Visualize installed Skills and symlink status across AI agents. GUI for managing skills with 21 AI agents support and 26 themes.',
-    category: 'Desktop App',
-    href: 'https://skills-desktop.vercel.app/',
-    logo: electronLogo,
-    featured: true,
-  },
-  {
-    name: 'Skills',
-    description:
-      'Agent skills for AI coding assistants. Reusable skill modules for Claude Code, Cursor, Codex, Gemini CLI, and more.',
-    category: 'Developer Tool',
-    href: 'https://github.com/laststance/skills',
-    logo: shellLogo,
-    featured: true,
-  },
-  {
-    name: 'Tailwind CSS Canonical Classes',
-    description:
-      'Automatically convert non-canonical Tailwind CSS v4 classes to their canonical equivalents. Prettier plugin, CLI, and core library.',
-    category: 'NPM Package',
-    href: 'https://github.com/laststance/tailwindcss-canonical-classes-monrepo',
-    logo: tailwindLogo,
-    featured: true,
-  },
-  {
-    name: '@laststance/redux-storage-middleware',
-    description:
-      'SSR-safe Redux Toolkit middleware for localStorage persistence with selective slice hydration and performance optimization.',
-    category: 'NPM Package',
-    href: 'https://github.com/laststance/redux-strorage-middeware',
-    logo: reduxLogo,
-    featured: true,
-  },
-  {
-    name: 'GitBox',
-    description:
-      'A web application for managing GitHub repositories in Kanban board format. Organize your repos visually and boost productivity.',
-    category: 'Web App',
-    href: 'https://gitbox-laststance.vercel.app/',
-    logo: git,
-    featured: true,
-  },
-  {
-    name: 'react-lightbox',
-    description:
-      'A flexible and accessible React lightbox component for displaying images with keyboard navigation and touch support.',
-    category: 'React Library',
-    href: 'https://github.com/laststance/react-lightbox',
-    logo: reactLogo,
-    featured: true,
-  },
-  {
-    name: 'electron-mcp-server',
-    description:
-      'A Model Context Protocol server for Electron applications. Bridge AI agents with desktop applications seamlessly.',
-    category: 'Developer Tool',
-    href: 'https://github.com/laststance/electron-mcp-server',
-    logo: mcpLogo,
-    featured: true,
-  },
-  {
-    name: 'mac-mcp-server',
-    description: 'MacOS MCP Server',
-    category: 'Developer Tool',
-    href: 'https://github.com/laststance/mac-mcp-server',
-    logo: mcpLogo,
-  },
-
-  // Chrome Extensions
-  {
-    name: 'Bookmark XP Explorer',
-    description:
-      'Manage Chrome bookmarks with a classic Windows XP explorer interface. Nostalgic yet functional.',
-    category: 'Chrome Extension',
-    href: 'https://chromewebstore.google.com/detail/bookmark-xp-explorer/bafnmajgbpafgeoafooklkfgamjbobpa',
-    logo: chromeLogo,
-  },
-  {
-    name: 'Clean URL',
-    description:
-      'Remove tracking parameters from URLs automatically, protecting your privacy while browsing.',
-    category: 'Chrome Extension',
-    href: 'https://chromewebstore.google.com/detail/clean-url/konddpmmdjghlicegcfdjehalocbkmpl',
-    logo: chromeLogo,
-  },
-
-  // macOS Apps
-  {
-    name: 'signage',
-    description:
-      'Dark self screen saver app for cooldown brain. Minimal distraction, maximum focus.',
-    category: 'macOS App',
-    href: 'https://github.com/laststance/signage',
-    logo: macosLogo,
-  },
-
-  // VS Code Extensions
-  {
-    name: 'Copy to',
-    description:
-      'A VSCode extension that adds a "Copy to..." option to the File Explorer context menu.',
-    category: 'VS Code Extension',
-    href: 'https://github.com/laststance/copy-to',
-    logo: vscodeLogo,
-  },
-
-  // NPM Packages
-  {
-    name: 'Claude Plugin Dashboard',
-    description:
-      'CLI dashboard for managing Claude Code plugins. Monitor and control your AI workflow.',
-    category: 'NPM Package',
-    href: 'https://github.com/laststance/claude-plugin-dashboard',
-    logo: npmLogo,
-  },
-  {
-    name: '@laststance/react-next-eslint-plugin',
-    description:
-      'A collection of ESLint plugins for React and Next.js. Enforce best practices automatically.',
-    category: 'NPM Package',
-    href: 'https://github.com/laststance/react-next-eslint-plugin',
-    logo: npmLogo,
-  },
-  {
-    name: 'eslint-config-ts-prefixer',
-    description:
-      'Opinionated ESLint config with meaningful runtime rules and beautiful formatters.',
-    category: 'NPM Package',
-    href: 'https://github.com/laststance/eslint-config-ts-prefixer',
-    logo: npmLogo,
-  },
-  {
-    name: 'git-commit-gpt',
-    description:
-      "AI-powered Git extension that generates commit messages using OpenAI's GPT models.",
-    category: 'NPM Package',
-    href: 'https://github.com/laststance/git-commit-gpt',
-    logo: npmLogo,
-  },
-  {
-    name: 'npm-publish-tool',
-    description:
-      'Streamlined tool for publishing npm packages with version management.',
-    category: 'NPM Package',
-    href: 'https://github.com/laststance/npm-publish-tool',
-    logo: npmLogo,
-  },
-  {
-    name: 'prettier-husky-lint-staged-installer',
-    description:
-      'One command to set up Prettier formatting on staged files at pre-commit.',
-    category: 'NPM Package',
-    href: 'https://github.com/laststance/prettier-husky-lint-staged-installer',
-    logo: npmLogo,
-  },
-
-  // Web Applications
-  {
-    name: 'Coffee Timer',
-    description:
-      'Simple timer PWA for coffee breaks with push notifications and customizable sounds.',
-    category: 'Web App',
-    href: 'https://github.com/laststance/coffee-timer',
-    logo: nextLogo,
-  },
-  {
-    name: 'do-i-need-umbrella',
-    description:
-      'Weather-based decision helper. Simple answer to a daily question.',
-    category: 'Web App',
-    href: 'https://github.com/laststance/do-i-need-an-umbrella',
-    logo: reactLogo,
-  },
-  {
-    name: 'Laststance.io',
-    description: 'This website. Built with Next.js, Tailwind, and MDX.',
-    category: 'Web App',
-    href: 'https://github.com/laststance/laststance.io',
-    logo: nextLogo,
-  },
-  {
-    name: 'nsx',
-    description:
-      'Personal tech resource logger. Curate and revisit valuable reads.',
-    category: 'Web App',
-    href: 'https://github.com/laststance/nsx',
-    logo: reactLogo,
-  },
-
-  // Templates & Starters
-  {
-    name: 'next-msw-integration',
-    description:
-      'Next.js 16 + MSW integration demo. Mock Service Worker setup for browser and server environments.',
-    category: 'Template',
-    href: 'https://github.com/laststance/next-msw-integration',
-    logo: nextLogo,
-  },
-  {
-    name: 'Create React App Vite',
-    description:
-      'Simple CRA-style Vite template. Familiar structure, modern tooling.',
-    category: 'Template',
-    href: 'https://github.com/laststance/create-react-app-vite',
-    logo: viteLogo,
-  },
-  {
-    name: 'vite-rtk-query',
-    description:
-      'Vite template for React + TypeScript + Redux Toolkit with RTK Query.',
-    category: 'Template',
-    href: 'https://github.com/laststance/vite-rtk-query',
-    logo: reduxLogo,
-  },
-  {
-    name: 'React TypeScript TodoMVC 2022',
-    description: 'Modern TodoMVC implementation. Clean code, modern patterns.',
-    category: 'Template',
-    href: 'https://github.com/laststance/react-typescript-todomvc-2022',
-    logo: reactLogo,
-  },
-
-  // Developer Tools
-  {
-    name: 'mui-storybook',
-    description:
-      'Storybook for MUI v5 default components. Visual component documentation.',
-    category: 'Developer Tool',
-    href: 'https://github.com/laststance/mui-storybook',
-    logo: storybookLogo,
-  },
-  {
-    name: 'Redux Front Page',
-    description:
-      'Solving Redux documentation fragmentation. One source of truth.',
-    category: 'Developer Tool',
-    href: 'https://github.com/laststance/Redux-Front-Page',
-    logo: reduxLogo,
-  },
-  {
-    name: 'dotfiles',
-    description:
-      'Personal Mac OS X setup manual. Reproducible development environment.',
-    category: 'Developer Tool',
-    href: 'https://github.com/ryota-murakami/dotfiles',
-    logo: shellLogo,
-  },
-]
-
-/**
- * Projects page with minimal list layout
+ * Projects page — Featured (status-labeled) / Archive (compressed reference) split.
  *
- * Design inspired by Linear and Rauno Freiberg's portfolio.
- * Features:
- * - Typography-first approach with generous whitespace
- * - Hover/focus accordion expansion for project details
- * - Flattened structure (no category grouping)
- * - Featured projects at the top
+ * Layout intent (DESIGN.md §7 + Walking Skeleton Phase 3):
+ * - Featured 7 — large expanded layout, status label drives single-accent hierarchy.
+ * - Archive 22 — 1-line compressed list, alphabetical, no motion / no status.
+ *
+ * The visual jump from large rows → compressed rows is the hierarchy signal,
+ * so the Featured section deliberately has no "Featured" heading.
  */
 export default function Projects() {
   return (
     <Box as="main" mt={16} className="sm:mt-24 md:mt-32">
       <Container>
-        {/* Header */}
         <Box as="header" maxW="3xl">
           <Text as="h1" variant="h1">
             Projects
@@ -326,31 +43,59 @@ export default function Projects() {
           </Text>
         </Box>
 
-        {/* Project List */}
+        {/* Featured section — top, no heading (the typography itself signals importance) */}
         <Box
           as="section"
           mt={16}
           className="sm:mt-20 md:mt-24"
-          aria-label="Project list"
+          aria-label="Featured projects"
         >
-          {/* Top border */}
           <div className="border-t border-zinc-200/60 dark:border-zinc-700/40" />
-
-          {/* Projects */}
-          {projects.map((project, index) => (
-            <ProjectListItem
+          {FEATURED_PROJECTS.map((project, index) => (
+            <FeaturedProjectListItem
               key={project.name}
               name={project.name}
               description={project.description}
               category={project.category}
               href={project.href}
               logo={project.logo}
+              status={project.status}
               index={index}
             />
           ))}
         </Box>
 
-        {/* Icon Credits - Minimal footer */}
+        {/* Archive section — divider + heading + compressed list */}
+        <Box
+          as="section"
+          mt={16}
+          className="sm:mt-20 md:mt-24"
+          aria-label="Archive projects"
+        >
+          <Text
+            as="h2"
+            variant="overline"
+            color="muted"
+            mb={6}
+            className="text-zinc-500 dark:text-zinc-400"
+          >
+            Archive
+          </Text>
+          <ul className="border-t border-zinc-200/60 dark:border-zinc-700/40">
+            {ARCHIVE_PROJECTS.map((project) => (
+              <ArchiveProjectListItem
+                key={project.name}
+                name={project.name}
+                description={project.description}
+                category={project.category}
+                href={project.href}
+                logo={project.logo}
+              />
+            ))}
+          </ul>
+        </Box>
+
+        {/* Icon Credits */}
         <Box as="section" mt={16}>
           <Text
             as="p"

--- a/src/components/ArchiveProjectListItem.tsx
+++ b/src/components/ArchiveProjectListItem.tsx
@@ -1,0 +1,76 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+import { Text } from '@/components/ui/primitives'
+import { type ArchiveProject } from '@/lib/projects'
+
+/**
+ * Archive project row — compressed 1-line layout, no expand/motion.
+ *
+ * Design intent (DESIGN.md §6 motion exception): Archive is a reference list,
+ * not "new content arrival" — so no entrance stagger, no hover accordion.
+ * Static-by-design keeps the visual hierarchy with Featured intact.
+ *
+ * Accessibility:
+ * - `min-h-[44px]` + `py-4` meets the iOS HIG 44pt tap target floor.
+ * - `title={description}` provides hover/tooltip context without an accordion.
+ * - `aria-label` is composed from name + category for clear screen-reader output.
+ *
+ * @param name - Project name
+ * @param description - Brief description (surfaces only via native title tooltip)
+ * @param category - Category label (right-aligned, mono caption)
+ * @param href - External link
+ * @param logo - Project icon (small, reduced opacity)
+ *
+ * @example
+ * <ArchiveProjectListItem
+ *   name="Clean URL"
+ *   description="Remove tracking parameters..."
+ *   category="Chrome Extension"
+ *   href="https://chromewebstore.google.com/..."
+ *   logo={chromeLogo}
+ * />
+ */
+export function ArchiveProjectListItem({
+  name,
+  description,
+  category,
+  href,
+  logo,
+}: ArchiveProject) {
+  return (
+    <li className="border-b border-zinc-200/40 dark:border-zinc-800/40">
+      <Link
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={description}
+        aria-label={`${name} - ${category} (opens in new tab)`}
+        className="group flex min-h-[44px] items-center gap-3 py-4 outline-none focus-visible:ring-2 focus-visible:ring-teal-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:gap-4 dark:focus-visible:ring-offset-zinc-900"
+      >
+        <Image
+          src={logo}
+          alt=""
+          className="h-5 w-5 shrink-0 opacity-70 transition-opacity group-hover:opacity-100"
+          unoptimized
+        />
+        <Text
+          as="span"
+          variant="bodySmall"
+          className="min-w-0 truncate text-zinc-700 group-hover:text-zinc-900 dark:text-zinc-300 dark:group-hover:text-zinc-50"
+        >
+          {name}
+        </Text>
+        <Text
+          as="span"
+          variant="caption"
+          color="muted"
+          transform="uppercase"
+          className="ml-auto shrink-0 font-mono text-xs text-zinc-400 dark:text-zinc-500"
+        >
+          {category}
+        </Text>
+      </Link>
+    </li>
+  )
+}

--- a/src/components/FeaturedProjectListItem.tsx
+++ b/src/components/FeaturedProjectListItem.tsx
@@ -1,70 +1,64 @@
 'use client'
 
 import { motion } from 'motion/react'
-import { type StaticImageData } from 'next/image'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useState } from 'react'
 
 import { Text } from '@/components/ui/primitives'
+import { type FeaturedProject } from '@/lib/projects'
 import { cn } from '@/lib/utils'
 
-/**
- * Project data structure for the minimal list layout
- */
-type ProjectListItemProps = {
-  /** Project name - displayed prominently */
-  name: string
-  /** Brief description - shown on expand */
-  description: string
-  /** Category label - displayed right-aligned */
-  category: string
-  /** External link */
-  href: string
-  /** Project logo */
-  logo: StaticImageData
-  /** Animation delay index for staggered entrance */
+type FeaturedProjectListItemProps = FeaturedProject & {
+  /** Stagger entrance animation index (Featured 0..6) */
   index?: number
 }
 
 /**
- * Minimal list-style project item with Motion-powered hover/focus accordion.
+ * Featured project row — large expanded layout with author-decided status label.
  *
- * Design inspired by Linear and Henry's Portfolio - typography-first approach
- * with generous whitespace and smooth spring animations.
+ * Visual treatment per DESIGN.md §7 (Status Label Vocabulary):
+ * - `Active` → teal accent (the one project receiving daily polish)
+ * - Other 4 statuses → zinc-400/500 muted
+ * - All statuses share `font-mono uppercase tracking-wider` for editorial uniformity
  *
- * Features:
- * - Staggered entrance animation on page load
- * - Spring physics for natural accordion expand/collapse
- * - Height: auto animation (Motion's killer feature)
- * - Arrow animation with spring physics
+ * Motion budget per DESIGN.md §6:
+ * - Staggered entrance (0.05s × index)
+ * - Spring-physics arrow + accordion height on hover/focus
  *
- * @param name - Project name (large, bold typography)
+ * @param name - Project name
  * @param description - Brief description (revealed on hover/focus)
  * @param category - Category label (right-aligned, muted)
- * @param href - Link to project
+ * @param href - External link to the project
  * @param logo - Project icon
- * @param index - For staggered animation delays
+ * @param status - Author-decided 1-of-5 status label (DESIGN.md §7)
+ * @param index - Stagger animation delay index
  *
  * @example
- * <ProjectListItem
- *   name="GitBox"
- *   description="Manage GitHub repositories in Kanban format."
- *   category="Web App"
- *   href="https://gitbox.vercel.app"
- *   logo={gitLogo}
+ * <FeaturedProjectListItem
+ *   name="Skills Desktop"
+ *   description="Visualize installed Skills..."
+ *   category="Desktop App"
+ *   href="https://skills-desktop.vercel.app/"
+ *   logo={electronLogo}
+ *   status="Active"
  *   index={0}
  * />
  */
-export function ProjectListItem({
+export function FeaturedProjectListItem({
   name,
   description,
   category,
   href,
   logo,
+  status,
   index = 0,
-}: ProjectListItemProps) {
+}: FeaturedProjectListItemProps) {
   const [isExpanded, setIsExpanded] = useState(false)
+
+  // Only `Active` consumes the accent token; others stay muted.
+  // Single-accent pattern preserves editorial uniformity while signaling priority.
+  const isActiveStatus = status === 'Active'
 
   return (
     <motion.article
@@ -79,7 +73,6 @@ export function ProjectListItem({
       onHoverEnd={() => setIsExpanded(false)}
       className={cn(
         'relative',
-        // Border
         'border-b border-zinc-200/60 dark:border-zinc-700/40',
         'hover:border-zinc-300/80 dark:hover:border-zinc-600/60',
       )}
@@ -96,13 +89,11 @@ export function ProjectListItem({
           'focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-900',
           'rounded-sm',
         )}
-        aria-label={`${name} - ${category} (opens in new tab)`}
+        aria-label={`${name} - ${status}, ${category} (opens in new tab)`}
       >
-        {/* Main row: Logo + Name | Category + Arrow */}
+        {/* Main row: Logo + Name | Status + Category + Arrow */}
         <div className="flex items-center justify-between gap-4">
-          {/* Left: Logo + Name */}
           <div className="flex min-w-0 items-center gap-4 sm:gap-6">
-            {/* Logo */}
             <div
               className={cn(
                 'flex h-12 w-12 shrink-0 items-center justify-center',
@@ -119,7 +110,6 @@ export function ProjectListItem({
               />
             </div>
 
-            {/* Project Name */}
             <Text
               as="h2"
               variant="h3"
@@ -129,20 +119,31 @@ export function ProjectListItem({
             </Text>
           </div>
 
-          {/* Right: Category + Arrow */}
           <div className="flex shrink-0 items-center gap-3 sm:gap-6">
-            {/* Category Label */}
+            {/* Status label — Active only consumes the accent token */}
+            <Text
+              as="span"
+              variant="caption"
+              color={isActiveStatus ? 'accent' : undefined}
+              transform="uppercase"
+              className={cn(
+                'hidden font-mono tracking-wider sm:inline-block',
+                !isActiveStatus && 'text-zinc-400 dark:text-zinc-500',
+              )}
+            >
+              {status}
+            </Text>
+
             <Text
               as="span"
               variant="caption"
               color="muted"
               transform="uppercase"
-              className="hidden sm:block text-zinc-400 dark:text-zinc-500"
+              className="hidden text-zinc-400 sm:block dark:text-zinc-500"
             >
               {category}
             </Text>
 
-            {/* Arrow Icon with Motion spring animation */}
             <motion.svg
               animate={{ x: isExpanded ? 4 : 0 }}
               transition={{ type: 'spring', stiffness: 400, damping: 25 }}
@@ -167,7 +168,7 @@ export function ProjectListItem({
           </div>
         </div>
 
-        {/* Expandable Content with Motion height animation */}
+        {/* Expandable description with spring height animation */}
         <motion.div
           initial={false}
           animate={{
@@ -182,17 +183,29 @@ export function ProjectListItem({
           aria-hidden={!isExpanded}
         >
           <div className="pt-6 pl-16 sm:pl-18">
-            {/* Mobile category */}
-            <Text
-              as="span"
-              variant="overline"
-              color="muted"
-              className="mb-2 block sm:hidden text-zinc-400 dark:text-zinc-500"
-            >
-              {category}
-            </Text>
+            {/* Mobile-only: status + category stacked above description */}
+            <div className="mb-2 flex items-center gap-3 sm:hidden">
+              <Text
+                as="span"
+                variant="overline"
+                color={isActiveStatus ? 'accent' : undefined}
+                className={cn(
+                  'font-mono',
+                  !isActiveStatus && 'text-zinc-400 dark:text-zinc-500',
+                )}
+              >
+                {status}
+              </Text>
+              <Text
+                as="span"
+                variant="overline"
+                color="muted"
+                className="text-zinc-400 dark:text-zinc-500"
+              >
+                {category}
+              </Text>
+            </div>
 
-            {/* Description */}
             <Text variant="body" color="muted" className="max-w-2xl">
               {description}
             </Text>

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,0 +1,305 @@
+import { type StaticImageData } from 'next/image'
+
+import chromeLogo from '@/images/logos/icons8-chrome-48.png'
+import electronLogo from '@/images/logos/icons8-electron-48.png'
+import git from '@/images/logos/icons8-git-48.png'
+import macosLogo from '@/images/logos/icons8-macos-48.png'
+import nextLogo from '@/images/logos/icons8-nextjs-48.png'
+import npmLogo from '@/images/logos/icons8-npm-48.png'
+import reactLogo from '@/images/logos/icons8-react-a-javascript-library-for-building-user-interfaces-32.png'
+import reduxLogo from '@/images/logos/icons8-redux-48.png'
+import shellLogo from '@/images/logos/icons8-shell-40.png'
+import storybookLogo from '@/images/logos/icons8-storybook-48.png'
+import tailwindLogo from '@/images/logos/icons8-tailwindcss-48.png'
+import viteLogo from '@/images/logos/icons8-vite-48.png'
+import vscodeLogo from '@/images/logos/icons8-vscode-48.png'
+import mcpLogo from '@/images/logos/mcp.svg'
+
+/**
+ * Author-decided status vocabulary for featured projects.
+ * Fixed 5 values — see DESIGN.md §7 (Status Label Vocabulary).
+ *
+ * - `Active`     — pixel 単位で改善中 (the one project receiving daily polish)
+ * - `Daily tool` — 今も毎日触ってる (battle-tested, used in author's own workflow)
+ * - `Experiment` — 証明系の思想実験 (proving an idea, may pivot or stop)
+ * - `Maintained` — bugfix のみ受ける (stable, no new features planned)
+ * - `Paused`     — 一時停止 (deliberately on hold, not deprecated)
+ */
+export type ProjectStatus =
+  | 'Active'
+  | 'Daily tool'
+  | 'Experiment'
+  | 'Maintained'
+  | 'Paused'
+
+/**
+ * Archive project — minimal metadata for compressed 1-line display.
+ * No status label (Archive projects are intentionally label-less per design).
+ */
+export type ArchiveProject = {
+  name: string
+  description: string
+  category: string
+  href: string
+  logo: StaticImageData
+}
+
+/**
+ * Featured project — extends ArchiveProject with required status label.
+ * Used by `FeaturedProjectListItem` which expects `status` to drive accent color.
+ */
+export type FeaturedProject = ArchiveProject & {
+  status: ProjectStatus
+}
+
+/**
+ * Featured 7 — hand-curated, status-labeled, large display.
+ * Order is intentional (author-curated importance), NOT alphabetical.
+ *
+ * Updated 2026-05-17 (Phase 3 Step 0 worksheet — Preset A: recent-skewed).
+ */
+export const FEATURED_PROJECTS: readonly FeaturedProject[] = [
+  {
+    name: 'Skills Desktop',
+    description:
+      'Visualize installed Skills and symlink status across AI agents. GUI for managing skills with 21 AI agents support and 26 themes.',
+    category: 'Desktop App',
+    href: 'https://skills-desktop.vercel.app/',
+    logo: electronLogo,
+    status: 'Active',
+  },
+  {
+    name: 'Skills',
+    description:
+      'Agent skills for AI coding assistants. Reusable skill modules for Claude Code, Cursor, Codex, Gemini CLI, and more.',
+    category: 'Developer Tool',
+    href: 'https://github.com/laststance/skills',
+    logo: shellLogo,
+    status: 'Daily tool',
+  },
+  {
+    name: 'Tailwind CSS Canonical Classes',
+    description:
+      'Automatically convert non-canonical Tailwind CSS v4 classes to their canonical equivalents. Prettier plugin, CLI, and core library.',
+    category: 'NPM Package',
+    href: 'https://github.com/laststance/tailwindcss-canonical-classes-monrepo',
+    logo: tailwindLogo,
+    status: 'Active',
+  },
+  {
+    name: '@laststance/redux-storage-middleware',
+    description:
+      'SSR-safe Redux Toolkit middleware for localStorage persistence with selective slice hydration and performance optimization.',
+    category: 'NPM Package',
+    href: 'https://github.com/laststance/redux-strorage-middeware',
+    logo: reduxLogo,
+    status: 'Maintained',
+  },
+  {
+    name: 'GitBox',
+    description:
+      'A web application for managing GitHub repositories in Kanban board format. Organize your repos visually and boost productivity.',
+    category: 'Web App',
+    href: 'https://gitbox-laststance.vercel.app/',
+    logo: git,
+    status: 'Daily tool',
+  },
+  {
+    name: 'react-lightbox',
+    description:
+      'A flexible and accessible React lightbox component for displaying images with keyboard navigation and touch support.',
+    category: 'React Library',
+    href: 'https://github.com/laststance/react-lightbox',
+    logo: reactLogo,
+    status: 'Maintained',
+  },
+  {
+    name: 'electron-mcp-server',
+    description:
+      'A Model Context Protocol server for Electron applications. Bridge AI agents with desktop applications seamlessly.',
+    category: 'Developer Tool',
+    href: 'https://github.com/laststance/electron-mcp-server',
+    logo: mcpLogo,
+    status: 'Experiment',
+  },
+]
+
+/**
+ * Archive — alphabetical (case-insensitive) for predictable scanning.
+ * No author-curated order, no status labels — pure reference list.
+ */
+export const ARCHIVE_PROJECTS: readonly ArchiveProject[] = [
+  {
+    name: '@laststance/react-next-eslint-plugin',
+    description:
+      'A collection of ESLint plugins for React and Next.js. Enforce best practices automatically.',
+    category: 'NPM Package',
+    href: 'https://github.com/laststance/react-next-eslint-plugin',
+    logo: npmLogo,
+  },
+  {
+    name: 'Bookmark XP Explorer',
+    description:
+      'Manage Chrome bookmarks with a classic Windows XP explorer interface. Nostalgic yet functional.',
+    category: 'Chrome Extension',
+    href: 'https://chromewebstore.google.com/detail/bookmark-xp-explorer/bafnmajgbpafgeoafooklkfgamjbobpa',
+    logo: chromeLogo,
+  },
+  {
+    name: 'Claude Plugin Dashboard',
+    description:
+      'CLI dashboard for managing Claude Code plugins. Monitor and control your AI workflow.',
+    category: 'NPM Package',
+    href: 'https://github.com/laststance/claude-plugin-dashboard',
+    logo: npmLogo,
+  },
+  {
+    name: 'Clean URL',
+    description:
+      'Remove tracking parameters from URLs automatically, protecting your privacy while browsing.',
+    category: 'Chrome Extension',
+    href: 'https://chromewebstore.google.com/detail/clean-url/konddpmmdjghlicegcfdjehalocbkmpl',
+    logo: chromeLogo,
+  },
+  {
+    name: 'Coffee Timer',
+    description:
+      'Simple timer PWA for coffee breaks with push notifications and customizable sounds.',
+    category: 'Web App',
+    href: 'https://github.com/laststance/coffee-timer',
+    logo: nextLogo,
+  },
+  {
+    name: 'Copy to',
+    description:
+      'A VSCode extension that adds a "Copy to..." option to the File Explorer context menu.',
+    category: 'VS Code Extension',
+    href: 'https://github.com/laststance/copy-to',
+    logo: vscodeLogo,
+  },
+  {
+    name: 'Create React App Vite',
+    description:
+      'Simple CRA-style Vite template. Familiar structure, modern tooling.',
+    category: 'Template',
+    href: 'https://github.com/laststance/create-react-app-vite',
+    logo: viteLogo,
+  },
+  {
+    name: 'do-i-need-umbrella',
+    description:
+      'Weather-based decision helper. Simple answer to a daily question.',
+    category: 'Web App',
+    href: 'https://github.com/laststance/do-i-need-an-umbrella',
+    logo: reactLogo,
+  },
+  {
+    name: 'dotfiles',
+    description:
+      'Personal Mac OS X setup manual. Reproducible development environment.',
+    category: 'Developer Tool',
+    href: 'https://github.com/ryota-murakami/dotfiles',
+    logo: shellLogo,
+  },
+  {
+    name: 'eslint-config-ts-prefixer',
+    description:
+      'Opinionated ESLint config with meaningful runtime rules and beautiful formatters.',
+    category: 'NPM Package',
+    href: 'https://github.com/laststance/eslint-config-ts-prefixer',
+    logo: npmLogo,
+  },
+  {
+    name: 'git-commit-gpt',
+    description:
+      "AI-powered Git extension that generates commit messages using OpenAI's GPT models.",
+    category: 'NPM Package',
+    href: 'https://github.com/laststance/git-commit-gpt',
+    logo: npmLogo,
+  },
+  {
+    name: 'Laststance.io',
+    description: 'This website. Built with Next.js, Tailwind, and MDX.',
+    category: 'Web App',
+    href: 'https://github.com/laststance/laststance.io',
+    logo: nextLogo,
+  },
+  {
+    name: 'mac-mcp-server',
+    description: 'MacOS MCP Server',
+    category: 'Developer Tool',
+    href: 'https://github.com/laststance/mac-mcp-server',
+    logo: mcpLogo,
+  },
+  {
+    name: 'mui-storybook',
+    description:
+      'Storybook for MUI v5 default components. Visual component documentation.',
+    category: 'Developer Tool',
+    href: 'https://github.com/laststance/mui-storybook',
+    logo: storybookLogo,
+  },
+  {
+    name: 'next-msw-integration',
+    description:
+      'Next.js 16 + MSW integration demo. Mock Service Worker setup for browser and server environments.',
+    category: 'Template',
+    href: 'https://github.com/laststance/next-msw-integration',
+    logo: nextLogo,
+  },
+  {
+    name: 'npm-publish-tool',
+    description:
+      'Streamlined tool for publishing npm packages with version management.',
+    category: 'NPM Package',
+    href: 'https://github.com/laststance/npm-publish-tool',
+    logo: npmLogo,
+  },
+  {
+    name: 'nsx',
+    description:
+      'Personal tech resource logger. Curate and revisit valuable reads.',
+    category: 'Web App',
+    href: 'https://github.com/laststance/nsx',
+    logo: reactLogo,
+  },
+  {
+    name: 'prettier-husky-lint-staged-installer',
+    description:
+      'One command to set up Prettier formatting on staged files at pre-commit.',
+    category: 'NPM Package',
+    href: 'https://github.com/laststance/prettier-husky-lint-staged-installer',
+    logo: npmLogo,
+  },
+  {
+    name: 'React TypeScript TodoMVC 2022',
+    description: 'Modern TodoMVC implementation. Clean code, modern patterns.',
+    category: 'Template',
+    href: 'https://github.com/laststance/react-typescript-todomvc-2022',
+    logo: reactLogo,
+  },
+  {
+    name: 'Redux Front Page',
+    description:
+      'Solving Redux documentation fragmentation. One source of truth.',
+    category: 'Developer Tool',
+    href: 'https://github.com/laststance/Redux-Front-Page',
+    logo: reduxLogo,
+  },
+  {
+    name: 'signage',
+    description:
+      'Dark self screen saver app for cooldown brain. Minimal distraction, maximum focus.',
+    category: 'macOS App',
+    href: 'https://github.com/laststance/signage',
+    logo: macosLogo,
+  },
+  {
+    name: 'vite-rtk-query',
+    description:
+      'Vite template for React + TypeScript + Redux Toolkit with RTK Query.',
+    category: 'Template',
+    href: 'https://github.com/laststance/vite-rtk-query',
+    logo: reduxLogo,
+  },
+]


### PR DESCRIPTION
## Summary

Walking Skeleton Phase 3 — refactor `/projects` from a flat 30-project grid into a **Featured / Archive** split.

- **Featured (7 large rows)** — author-decided status labels from a fixed 5-word vocabulary (Active / Daily tool / Experiment / Maintained / Paused). Only `Active` consumes the teal accent token; the other four stay zinc-muted. Single-accent rule per DESIGN.md §3+§7.
- **Archive (22 compressed rows)** — alphabetical, 1-line, no motion, `min-h-11` for iOS HIG tap targets.
- Data + types centralized in `src/lib/projects.ts` (`FeaturedProject extends ArchiveProject` with required `status`).
- Net diff: −439 lines despite two new components, because the inline 30-project array and 14 logo imports collapse into one source of truth.

## Dependency on Phase 1

Code-wise this PR is self-contained — the `Text color="accent"` token already exists in `main`. The DESIGN.md cross-references that mention `src/lib/projects.ts` and the Featured/Archive split live on **#1637 (feat/design-md)** and are correctly phrased as forward references. Phase 1 should land first so reviewers can read DESIGN.md alongside this change; nothing here will block on it.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 166/166 Vitest green
- [x] `pnpm build` — `/projects` prerenders as Static
- [x] `pnpm exec playwright test e2e/projects.spec.ts --reporter=list` — 24/24 green across Chrome / iPad Pro 11 / iPad Pro 11 landscape / iPhone 14
- [x] Manual visual check at 1280×900 and 390×844 (Chrome DevTools)
- [ ] Argos baseline diff — expected (this is the whole purpose of the PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects page now displays featured projects with status indicators (Active, Experiment, Daily tool, etc.) in a dedicated section.
  * Added archive section to showcase older projects separately.
  * Enhanced project organization for improved visibility and discoverability.

* **Tests**
  * Updated end-to-end tests to validate featured and archive project sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/laststance.io/pull/1639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->