### PR TITLE
fix(header): unify top margin to 96px, fix /articles title wrap

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -76,8 +76,9 @@ function MailIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
 }
 
 export default function About() {
+  // 96px top offset (mt-16 sm:mt-24) to match SimpleLayout, /projects, and the article pages.
   return (
-    <Container className="mt-16 sm:mt-32">
+    <Container className="mt-16 sm:mt-24">
       <div className="grid grid-cols-1 gap-y-16 lg:grid-cols-2 lg:grid-rows-[auto_1fr] lg:gap-y-12">
         <div className="lg:pl-20">
           <Box maxW="xs" px={2} className="lg:max-w-none">

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -81,8 +81,18 @@ export default async function ArticlesIndex({
 
   return (
     <SimpleLayout
-      title="Writing about new release, update and thought of Web Application Development."
-      intro={`In particular, I often write about React, CSS, JavaScript, TypeScript,and Node.js. collected in chronological order.`}
+      title={
+        <>
+          Writing about new release, update and thought of{' '}
+          {/* From the `sm` breakpoint up, keep this phrase on one line so "Web" never
+              strands at a line end. On phones we let it wrap normally — forcing one line
+              there would push the text off the right edge of the screen. */}
+          <span className="sm:whitespace-nowrap">
+            Web Application Development.
+          </span>
+        </>
+      }
+      intro={`In particular, I often write about React, CSS, JavaScript, TypeScript, and Node.js. collected in chronological order.`}
     >
       <Box className="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40">
         <Box className="max-w-3xl">

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -29,8 +29,10 @@ export const metadata: Metadata = {
  * so the Featured section deliberately has no "Featured" heading.
  */
 export default function Projects() {
+  // Match SimpleLayout's header offset (mt-16 sm:mt-24) so /projects lines up
+  // with /uses and /articles — the earlier md:mt-32 left a visibly wider gap here.
   return (
-    <Box as="main" mt={16} className="sm:mt-24 md:mt-32">
+    <Box as="main" mt={16} className="sm:mt-24">
       <Container>
         <Box as="header" maxW="3xl">
           <Text as="h1" variant="h1">

--- a/src/components/ArticleLayout.tsx
+++ b/src/components/ArticleLayout.tsx
@@ -15,10 +15,11 @@ export function ArticleLayout({
   //const router = useRouter()
   //const { previousPathname } = useContext(AppContext)
 
+  // 96px top offset (mt-16 sm:mt-24) to match the listing pages and /about.
   return (
-    <Container className="mt-16 lg:mt-32">
+    <Container className="mt-16 sm:mt-24">
       <div className="xl:relative">
-        <div className="mx-auto max-w-[60rem]">
+        <div className="mx-auto max-w-240">
           {/* {previousPathname && ( */}
           {/*   <button */}
           {/*     type="button" */}

--- a/src/components/SimpleLayout.tsx
+++ b/src/components/SimpleLayout.tsx
@@ -12,9 +12,10 @@ export function SimpleLayout({
   intro: string
 }) {
   return (
-    <Container className="mt-16 sm:mt-32">
+    <Container className="mt-16 sm:mt-24">
       <Box as="header" maxW="2xl">
-        <Text as="h1" variant="h1">
+        {/* text-balance: let the browser even out line widths on long, wrapping titles */}
+        <Text as="h1" variant="h1" className="text-balance">
           {title}
         </Text>
         <Text variant="body" color="muted" mt={6}>


### PR DESCRIPTION
## What

Fixes the broken Header layout reported on `/uses`, `/projects`, and `/articles`: the top margin was too wide and inconsistent across pages, and the `/articles` title wrapped awkwardly (the word "Web" was stranded at a line end).

### Changes

- **Unify top margin to 96px** (`mt-16 sm:mt-24`) across every header surface:
  - `SimpleLayout` (`/uses`, `/articles`): `sm:mt-32` → `sm:mt-24`
  - `/projects`: `sm:mt-24 md:mt-32` → `sm:mt-24`
  - `/about`: `sm:mt-32` → `sm:mt-24`
  - `ArticleLayout` (article detail): `lg:mt-32` → `sm:mt-24`
- **`/articles` title line-break (mobile-safe):** wrap `Web Application Development.` in `sm:whitespace-nowrap` so "Web" no longer strands at a line end from the `sm` breakpoint up; phones still wrap naturally with no horizontal overflow.
- **Typo:** `TypeScript,and` → `TypeScript, and` in the `/articles` intro.
- `ArticleLayout`: Prettier normalized `max-w-[60rem]` → `max-w-240` (mathematically identical: 240 × 0.25rem = 60rem).

## Testing

- 📏 Measured h1 top offset at 1280px: `/uses`, `/projects`, `/articles` all = 160px; `/about` & article-detail `Container` = 96px — uniform across all surfaces.
- 📱 Verified `/articles` title at 375 / 640 / 1280px: phones wrap with no overflow; "Web" stays on one line from `sm` up.
- ✅ ESLint (exit 0), Prettier `--check` (all files clean), `tsc` (exit 0).

## Notes

- UI-impacting (header spacing + title wrap). Affects `/uses`, `/projects`, `/articles`, `/about`, and article detail pages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved vertical spacing consistency across pages for better visual alignment.
  * Enhanced title text wrapping on smaller screens to prevent awkward line breaks.

* **Documentation**
  * Added clarifying comments for spacing alignment standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/laststance.io/pull/1647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->