### PR TITLE
style: fix spacing and responsive layout audit findings

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -339,7 +339,7 @@ The union will live next to the data once `src/lib/projects.ts` lands in Phase 3
 ### Page widths
 
 - **Outer shell** — `Container` (`src/components/Container.tsx`) wraps with `max-w-7xl` (1280px) + horizontal padding.
-- **Article / prose body** — `max-w-[60rem]` (960px) reading column inside the `max-w-5xl` (1024px) Container at `lg:` (~32px gutters either side, matching tkdodo.eu). Smaller screens collapse to the parent's full width. Prose's internal `max-w` is `none` — width is controlled by the layout wrapper.
+- **Article / prose body** — `max-w-[72ch]` reading column inside the `max-w-5xl` (1024px) Container at `lg:`. This keeps long-form paragraphs near the 45–75 character reading range; smaller screens collapse to the parent's full width. Prose's internal `max-w` is `none` — width is controlled by the layout wrapper, while wide tables use local horizontal scrolling.
 - **Hero intro block** — `<Box maxW="2xl">` so the lead paragraph stays at ~50–60 chars/line.
 
 ### Home page — 2-column grid

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -350,7 +350,7 @@ The union will live next to the data once `src/lib/projects.ts` lands in Phase 3
 <div className="mx-auto grid max-w-xl grid-cols-1 gap-y-20 xl:max-w-none xl:grid-cols-2">
   <VStack gap={16}>{/* Left: Recent Articles */}</VStack>
   <div className="space-y-10 xl:pl-24">
-    {/* Right: NowPanel (planned for Phase 2). Currently GithubFeedList. */}
+    <NowPanel />
   </div>
 </div>
 ```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -347,16 +347,16 @@ The union will live next to the data once `src/lib/projects.ts` lands in Phase 3
 `src/app/page.tsx`:
 
 ```tsx
-<div className="mx-auto grid max-w-xl grid-cols-1 gap-y-20 lg:max-w-none lg:grid-cols-2">
+<div className="mx-auto grid max-w-xl grid-cols-1 gap-y-20 xl:max-w-none xl:grid-cols-2">
   <VStack gap={16}>{/* Left: Recent Articles */}</VStack>
-  <div className="space-y-10 lg:pl-16 xl:pl-24">
+  <div className="space-y-10 xl:pl-24">
     {/* Right: NowPanel (planned for Phase 2). Currently GithubFeedList. */}
   </div>
 </div>
 ```
 
 - Mobile / tablet: single column, right-column content stacks below the left.
-- `lg:` and up: 50/50 columns with extra left-padding on the right column (`lg:pl-16 xl:pl-24`) for visual breathing.
+- `xl:` and up: 50/50 columns with extra left-padding on the right column (`xl:pl-24`) for visual breathing.
 
 ### Projects page (post-Phase 3 refactor)
 

--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -27,3 +27,109 @@ test('home page shows the Now panel with author-written focus items', async ({
     page.getByRole('heading', { level: 3, name: 'OSS at @laststance' }),
   ).toBeVisible()
 })
+
+test('home page keeps the Now panel inside every viewport from 320px to desktop', async ({
+  page,
+}) => {
+  // Arrange
+  const viewportWidths = [
+    320, 375, 390, 639, 640, 767, 768, 1023, 1024, 1279, 1280, 1440,
+  ]
+  await page.setViewportSize({ width: viewportWidths[0], height: 900 })
+  await page.goto('/')
+  const nowPanel = page.locator('[data-react-component="NowPanel"]')
+
+  // Act
+  const layouts = []
+  for (const viewportWidth of viewportWidths) {
+    await page.setViewportSize({ width: viewportWidth, height: 900 })
+    layouts.push({
+      nowPanelBounds: await nowPanel.boundingBox(),
+      pageWidths: await page.evaluate(() => ({
+        body: document.body.scrollWidth,
+        viewport: document.documentElement.clientWidth,
+      })),
+      viewportWidth,
+    })
+  }
+
+  // Assert
+  for (const { nowPanelBounds, pageWidths, viewportWidth } of layouts) {
+    expect(nowPanelBounds, `${viewportWidth}px Now panel`).not.toBeNull()
+    expect(
+      nowPanelBounds?.x,
+      `${viewportWidth}px Now panel left`,
+    ).toBeGreaterThanOrEqual(0)
+    expect(
+      (nowPanelBounds?.x ?? 0) + (nowPanelBounds?.width ?? 0),
+      `${viewportWidth}px Now panel right`,
+    ).toBeLessThanOrEqual(viewportWidth)
+    expect(pageWidths, `${viewportWidth}px document width`).toEqual({
+      body: viewportWidth,
+      viewport: viewportWidth,
+    })
+  }
+})
+
+test('home page waits until 1280px before placing Now beside articles', async ({
+  page,
+}) => {
+  // Arrange
+  await page.setViewportSize({ width: 1024, height: 900 })
+  await page.goto('/')
+  const articles = page.locator('main article')
+  const nowPanel = page.locator('[data-react-component="NowPanel"]')
+
+  // Act
+  const mediumLastArticleBounds = await articles.last().boundingBox()
+  const mediumNowPanelBounds = await nowPanel.boundingBox()
+  await page.setViewportSize({ width: 1280, height: 900 })
+  const wideFirstArticleBounds = await articles.first().boundingBox()
+  const wideNowPanelBounds = await nowPanel.boundingBox()
+
+  // Assert
+  expect(mediumLastArticleBounds).not.toBeNull()
+  expect(mediumNowPanelBounds).not.toBeNull()
+  expect(mediumNowPanelBounds?.y).toBeGreaterThan(
+    (mediumLastArticleBounds?.y ?? 0) + (mediumLastArticleBounds?.height ?? 0),
+  )
+  expect(wideFirstArticleBounds).not.toBeNull()
+  expect(wideNowPanelBounds).not.toBeNull()
+  expect(wideNowPanelBounds?.y).toBeCloseTo(wideFirstArticleBounds?.y ?? 0, 0)
+  expect(wideNowPanelBounds?.x).toBeGreaterThan(
+    (wideFirstArticleBounds?.x ?? 0) + (wideFirstArticleBounds?.width ?? 0),
+  )
+})
+
+test('home page provides 44px touch targets for compact navigation controls', async ({
+  page,
+}) => {
+  // Arrange
+  await page.setViewportSize({ width: 320, height: 900 })
+  await page.goto('/')
+  const touchTargets = [
+    page.getByRole('button', { name: 'Toggle mobile navigation menu' }),
+    page.getByRole('button', { name: "Open What's New dialog" }),
+    page.getByRole('button', { name: /Switch to .* theme|Toggle theme/ }),
+    page.getByRole('link', { name: 'Follow on Twitter' }),
+    page.getByRole('link', { name: 'Follow on Instagram' }),
+    page.getByRole('link', { name: 'Follow on GitHub' }),
+    page.getByRole('link', { name: 'Follow on LinkedIn' }),
+    page.locator('footer').getByRole('link', { name: 'About' }),
+    page.locator('footer').getByRole('link', { name: 'Projects' }),
+    page.locator('footer').getByRole('link', { name: 'Uses' }),
+    page.locator('footer').getByRole('link', { name: 'Keybinds' }),
+  ]
+
+  // Act
+  const touchTargetBounds = await Promise.all(
+    touchTargets.map(async (touchTarget) => touchTarget.boundingBox()),
+  )
+
+  // Assert
+  for (const touchTargetBoundsItem of touchTargetBounds) {
+    expect(touchTargetBoundsItem).not.toBeNull()
+    expect(touchTargetBoundsItem?.width).toBeGreaterThanOrEqual(44)
+    expect(touchTargetBoundsItem?.height).toBeGreaterThanOrEqual(44)
+  }
+})

--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -79,7 +79,7 @@ test('home page waits until 1280px before placing Now beside articles', async ({
 }) => {
   // Arrange
   await page.setViewportSize({ width: 1024, height: 900 })
-  await page.goto('/')
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
   const articles = page.locator('main article')
   const nowPanel = page.locator('[data-react-component="NowPanel"]')
 

--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -64,10 +64,13 @@ test('home page keeps the Now panel inside every viewport from 320px to desktop'
       (nowPanelBounds?.x ?? 0) + (nowPanelBounds?.width ?? 0),
       `${viewportWidth}px Now panel right`,
     ).toBeLessThanOrEqual(viewportWidth)
-    expect(pageWidths, `${viewportWidth}px document width`).toEqual({
-      body: viewportWidth,
-      viewport: viewportWidth,
-    })
+    expect(
+      pageWidths.body,
+      `${viewportWidth}px body width`,
+    ).toBeLessThanOrEqual(viewportWidth)
+    expect(pageWidths.viewport, `${viewportWidth}px viewport width`).toBe(
+      viewportWidth,
+    )
   }
 })
 

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -13,6 +13,9 @@ import { Mermaid } from '@/components/Mermaid'
  */
 type PreProps = ComponentPropsWithoutRef<'pre'>
 
+/** Props that MDX hands to a native table generated from Markdown. */
+type TableProps = ComponentPropsWithoutRef<'table'>
+
 /** Shape of the `<code>` element nested inside an MDX `<pre>` block. */
 type CodeChildProps = {
   className?: string
@@ -44,6 +47,25 @@ function extractText(children: unknown): string {
   return ''
 }
 
+/**
+ * Keeps wide MDX tables readable on narrow screens when the MDX renderer emits a native table.
+ * @param props - Native table props generated from the article's Markdown table.
+ * @returns A full-width table inside a locally scrollable mobile container.
+ * @example
+ * <ResponsiveTable><tbody><tr><td>Value</td></tr></tbody></ResponsiveTable>
+ */
+function ResponsiveTable({ className, ...props }: TableProps): ReactElement {
+  const tableClassName = className
+    ? `w-max min-w-full border-collapse ${className}`
+    : 'w-max min-w-full border-collapse'
+
+  return (
+    <div className="-mx-4 overflow-x-auto overscroll-x-contain px-4 pb-2 sm:mx-0 sm:px-0">
+      <table className={tableClassName} {...props} />
+    </div>
+  )
+}
+
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     ...components,
@@ -57,5 +79,6 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       }
       return <pre {...props} />
     },
+    table: ResponsiveTable,
   }
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -43,7 +43,7 @@ function SocialLink({
     <li className={clsx(className, 'flex')}>
       <Link
         href={href}
-        className="group flex text-base font-medium text-zinc-800 transition hover:text-teal-500 dark:text-zinc-200 dark:hover:text-teal-500 sm:text-lg"
+        className="group flex min-h-11 items-center text-base font-medium text-zinc-800 transition hover:text-teal-500 dark:text-zinc-200 dark:hover:text-teal-500 sm:text-lg"
         {...(isExternalLink && !isEmailLink
           ? {
               target: '_blank',

--- a/src/app/keybinds/KeybindsClient.tsx
+++ b/src/app/keybinds/KeybindsClient.tsx
@@ -69,13 +69,15 @@ const renderNestedCategorySection = (
         {subcategoryName}
       </h2>
     </button>
-    <table className="min-w-full border-collapse">
-      <tbody>
-        {Object.entries(subcategoryData).map(([action, shortcut]) =>
-          renderKeybindRow(action, shortcut),
-        )}
-      </tbody>
-    </table>
+    <div className="-mx-4 overflow-x-auto overscroll-x-contain px-4 pb-2 sm:mx-0 sm:px-0">
+      <table className="w-max min-w-full border-collapse">
+        <tbody>
+          {Object.entries(subcategoryData).map(([action, shortcut]) =>
+            renderKeybindRow(action, shortcut),
+          )}
+        </tbody>
+      </table>
+    </div>
   </div>
 )
 
@@ -133,17 +135,19 @@ export default function KeybindsClient({ keybinds }: KeybindsClientProps) {
               </>
             ) : (
               // Category without nested subcategories: render flat structure
-              <table className="min-w-full border-collapse">
-                <tbody>
-                  {Object.entries(categoryData).map(([action, value]) => {
-                    if (isNestedCategory(value)) {
-                      // This shouldn't happen for categories without nested subcategories, but handle it gracefully
-                      return null
-                    }
-                    return renderKeybindRow(action, value)
-                  })}
-                </tbody>
-              </table>
+              <div className="-mx-4 overflow-x-auto overscroll-x-contain px-4 pb-2 sm:mx-0 sm:px-0">
+                <table className="w-max min-w-full border-collapse">
+                  <tbody>
+                    {Object.entries(categoryData).map(([action, value]) => {
+                      if (isNestedCategory(value)) {
+                        // This shouldn't happen for categories without nested subcategories, but handle it gracefully
+                        return null
+                      }
+                      return renderKeybindRow(action, value)
+                    })}
+                  </tbody>
+                </table>
+              </div>
             )}
           </div>
         )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,7 @@ export default async function Home() {
               React/Node/TypeScript developer. Here is my independent OSS
               organization.
             </Text>
-            <HStack gap={6}>
+            <HStack gap={2}>
               <SocialLink
                 href="https://twitter.com/malloc007"
                 aria-label="Follow on Twitter"
@@ -65,13 +65,14 @@ export default async function Home() {
       </Container>
       <Photos />
       <Container className="mt-24 md:mt-28">
-        <div className="mx-auto grid max-w-xl grid-cols-1 gap-y-20 lg:max-w-none lg:grid-cols-2">
+        {/* Keep one column until 1280px so the sidebar never compresses article copy. */}
+        <div className="mx-auto grid max-w-xl grid-cols-1 gap-y-20 xl:max-w-none xl:grid-cols-2">
           <VStack gap={16}>
             {articles.map((article) => (
               <Article key={article.slug} article={article} />
             ))}
           </VStack>
-          <div className="space-y-10 lg:pl-16 xl:pl-24">
+          <div className="space-y-10 xl:pl-24">
             <NowPanel />
           </div>
         </div>

--- a/src/app/page/NowPanel.tsx
+++ b/src/app/page/NowPanel.tsx
@@ -16,7 +16,7 @@ export function NowPanel() {
   return (
     <section
       data-react-component="NowPanel"
-      className="max-xs:w-85 max-sm:w-90 md:w-95 max-lg:m-auto"
+      className="mx-auto w-full md:max-w-95 xl:mx-0"
     >
       <header className="mb-8 flex items-baseline justify-between gap-4">
         <h2 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">

--- a/src/app/page/SocialLink.tsx
+++ b/src/app/page/SocialLink.tsx
@@ -16,7 +16,7 @@ export function SocialLink({
   return (
     <Link
       href={href}
-      className="group -m-1 p-1"
+      className="group inline-flex size-11 items-center justify-center"
       {...(isExternalLink
         ? {
             target: '_blank',

--- a/src/app/uses/page.tsx
+++ b/src/app/uses/page.tsx
@@ -1,8 +1,9 @@
 import { type Metadata } from 'next'
 
-import { Card, CardTitle, CardDescription } from '@/components/Card'
+import { Card, CardTitle } from '@/components/Card'
 import { Section } from '@/components/Section'
 import { SimpleLayout } from '@/components/SimpleLayout'
+import { Text } from '@/components/ui/primitives'
 
 function ToolsSection({
   children,
@@ -25,11 +26,13 @@ function Tool({
   href?: string
 }) {
   return (
-    <Card as="li">
+    <Card as="li" className="gap-4">
       <CardTitle as="h3" href={href}>
         {title}
       </CardTitle>
-      <CardDescription>{children}</CardDescription>
+      <Text as="p" variant="body" color="muted" className="relative z-10">
+        {children}
+      </Text>
     </Card>
   )
 }

--- a/src/components/ArticleLayout.tsx
+++ b/src/components/ArticleLayout.tsx
@@ -19,7 +19,7 @@ export function ArticleLayout({
   return (
     <Container className="mt-16 sm:mt-24">
       <div className="xl:relative">
-        <div className="mx-auto max-w-240">
+        <div className="mx-auto max-w-[72ch]">
           {/* {previousPathname && ( */}
           {/*   <button */}
           {/*     type="button" */}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -21,7 +21,7 @@ export function Button({
   ...props
 }: ButtonProps) {
   className = clsx(
-    'inline-flex items-center gap-2 justify-center rounded-md py-2 px-3 text-sm outline-offset-2 transition active:transition-none',
+    'inline-flex min-h-11 items-center gap-2 justify-center rounded-md py-2 px-3 text-sm outline-offset-2 transition active:transition-none',
     variantStyles[variant],
     className,
   )

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -37,12 +37,16 @@ export function Card<T extends React.ElementType = 'div'>({
 
 export function CardLink({
   children,
+  className,
   ...props
 }: React.ComponentPropsWithoutRef<typeof Link>) {
   return (
     <>
       <div className="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 dark:bg-zinc-800/50 sm:-inset-x-6 sm:rounded-2xl" />
-      <Link {...props}>
+      <Link
+        className={clsx('inline-flex min-h-11 items-center', className)}
+        {...props}
+      >
         <span className="absolute -inset-x-4 -inset-y-6 z-20 sm:-inset-x-6 sm:rounded-2xl" />
         <span className="relative z-10">{children}</span>
       </Link>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,7 +12,7 @@ const NavLink: React.FC<ComponentProps<'a'>> = ({
   <Link
     {...rest}
     href={href}
-    className="transition hover:text-teal-500 dark:hover:text-teal-400"
+    className="inline-flex min-h-11 min-w-11 items-center justify-center transition hover:text-teal-500 dark:hover:text-teal-400"
   >
     {children}
   </Link>

--- a/src/components/Header/Avatar.tsx
+++ b/src/components/Header/Avatar.tsx
@@ -15,7 +15,13 @@ export function Avatar({
     <Link
       href="/"
       aria-label="Home"
-      className={clsx(className, 'pointer-events-auto')}
+      className={clsx(
+        className,
+        'pointer-events-auto',
+        large
+          ? 'block size-16'
+          : 'inline-flex size-11 items-center justify-center',
+      )}
       {...props}
     >
       <Image

--- a/src/components/Header/MobileNavItem.tsx
+++ b/src/components/Header/MobileNavItem.tsx
@@ -10,7 +10,12 @@ export function MobileNavItem({
 }) {
   return (
     <li>
-      <Popover.Button as={Link} href={href} {...rest} className="block py-2">
+      <Popover.Button
+        as={Link}
+        href={href}
+        {...rest}
+        className="flex min-h-11 items-center py-2"
+      >
         {children}
       </Popover.Button>
     </li>

--- a/src/components/Header/MobileNavigation.tsx
+++ b/src/components/Header/MobileNavigation.tsx
@@ -14,7 +14,7 @@ export function MobileNavigation(
       <Popover.Button
         aria-label="Toggle mobile navigation menu"
         aria-haspopup="menu"
-        className="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-zinc-800 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10 dark:hover:ring-white/20"
+        className="group flex min-h-11 items-center rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-zinc-800 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10 dark:hover:ring-white/20"
       >
         Menu
         <ChevronDownIcon
@@ -50,7 +50,10 @@ export function MobileNavigation(
             className="fixed inset-x-4 top-8 z-50 origin-top rounded-3xl bg-white p-8 ring-1 ring-zinc-900/5 dark:bg-zinc-900 dark:ring-zinc-800"
           >
             <div className="flex flex-row-reverse items-center justify-between">
-              <Popover.Button aria-label="Close menu" className="-m-1 p-1">
+              <Popover.Button
+                aria-label="Close menu"
+                className="inline-flex size-11 items-center justify-center"
+              >
                 <CloseIcon className="h-6 w-6 text-zinc-500 dark:text-zinc-400" />
               </Popover.Button>
               <h2 className="text-sm font-medium text-zinc-600 dark:text-zinc-400">

--- a/src/components/Header/NavItem.tsx
+++ b/src/components/Header/NavItem.tsx
@@ -17,7 +17,7 @@ export const NavItem: React.FC<ComponentProps<'a'>> = ({
       <Link
         href={href}
         className={clsx(
-          'relative block px-3 py-2 transition',
+          'relative inline-flex min-h-11 items-center px-3 py-2 transition',
           isActive ? 'text-teal-500 dark:text-teal-400' : 'link-hover',
         )}
         {...rest}

--- a/src/components/Header/ThemeToggle.tsx
+++ b/src/components/Header/ThemeToggle.tsx
@@ -30,7 +30,7 @@ export function ThemeToggle() {
     <button
       type="button"
       aria-label={mounted ? `Switch to ${otherTheme} theme` : 'Toggle theme'}
-      className="group rounded-full bg-white/90 px-3 py-2 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur-sm transition dark:bg-zinc-800/90 dark:ring-white/10 dark:hover:ring-white/20"
+      className="group min-h-11 min-w-11 rounded-full bg-white/90 px-3 py-2 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur-sm transition dark:bg-zinc-800/90 dark:ring-white/10 dark:hover:ring-white/20"
       onClick={handleToggle}
       onKeyDown={handleKeyDown}
     >

--- a/src/components/Header/WhatNew.tsx
+++ b/src/components/Header/WhatNew.tsx
@@ -26,7 +26,12 @@ const List: React.FC<Props> = ({ date, li }) => (
     <h3 className="font-bold text-lg">{date}</h3>
     <ul className="mt-4 ml-6 list-disc text-base">
       {li.map((v, i) => (
-        <li key={i}>{v}</li>
+        <li
+          key={i}
+          className="min-h-11 [&>a]:inline-flex [&>a]:min-h-11 [&>a]:items-center [&>a]:py-2"
+        >
+          {v}
+        </li>
       ))}
     </ul>
   </div>

--- a/src/components/Header/WhatNew.tsx
+++ b/src/components/Header/WhatNew.tsx
@@ -36,7 +36,11 @@ const WhatNew: React.FC = () => {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="ghost" aria-label="Open What's New dialog">
+        <Button
+          variant="ghost"
+          aria-label="Open What's New dialog"
+          className="h-11"
+        >
           What's New?
         </Button>
       </DialogTrigger>

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -106,8 +106,8 @@ function PaginationItem({
   rel,
 }: PaginationItemProps) {
   const className = cn(
-    // モバイル(< sm)は 44×44px (WCAG/HIG タップターゲット最小)、sm 以上は 36px に絞ってデスクトップでの主張を抑える
-    'inline-flex h-11 min-w-11 items-center justify-center rounded-md px-3 text-sm font-medium transition-colors sm:h-9 sm:min-w-9',
+    // Every breakpoint keeps the 44×44px WCAG/HIG minimum interaction target.
+    'inline-flex h-11 min-w-11 items-center justify-center rounded-md px-3 text-sm font-medium transition-colors',
     current
       ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900'
       : 'text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800',

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -37,7 +37,7 @@ export function Pagination({
   return (
     <nav
       aria-label="Pagination"
-      className="mt-12 flex items-center justify-center gap-1 sm:gap-2"
+      className="mt-12 grid w-full grid-cols-[auto_1fr_auto] items-center gap-1 sm:flex sm:justify-center sm:gap-2"
     >
       <PaginationItem
         href={hrefForPage(basePath, prevPage)}
@@ -48,26 +48,31 @@ export function Pagination({
         <span aria-hidden="true">←</span>
         <span className="sr-only sm:not-sr-only sm:ml-1">Previous</span>
       </PaginationItem>
-      {pages.map((entry, index) =>
-        entry === 'ellipsis' ? (
-          <span
-            key={`ellipsis-${index}`}
-            aria-hidden="true"
-            className="px-2 text-sm text-zinc-400 dark:text-zinc-500"
-          >
-            …
-          </span>
-        ) : (
-          <PaginationItem
-            key={entry}
-            href={hrefForPage(basePath, entry)}
-            current={entry === currentPage}
-            ariaLabel={`Go to page ${entry}`}
-          >
-            {entry}
-          </PaginationItem>
-        ),
-      )}
+      <span className="text-center text-sm tabular-nums text-zinc-500 sm:hidden dark:text-zinc-400">
+        Page {currentPage} of {totalPages}
+      </span>
+      <div className="hidden items-center gap-1 sm:flex sm:gap-2">
+        {pages.map((entry, index) =>
+          entry === 'ellipsis' ? (
+            <span
+              key={`ellipsis-${index}`}
+              aria-hidden="true"
+              className="px-2 text-sm text-zinc-400 dark:text-zinc-500"
+            >
+              …
+            </span>
+          ) : (
+            <PaginationItem
+              key={entry}
+              href={hrefForPage(basePath, entry)}
+              current={entry === currentPage}
+              ariaLabel={`Go to page ${entry}`}
+            >
+              {entry}
+            </PaginationItem>
+          ),
+        )}
+      </div>
       <PaginationItem
         href={hrefForPage(basePath, nextPage)}
         disabled={isLastPage}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,13 +38,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg md:w-full',
+        'fixed left-[50%] top-[50%] z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-4 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg sm:p-6 md:w-full',
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute top-2 right-2 inline-flex size-11 items-center justify-center rounded-md opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/typography.js
+++ b/typography.js
@@ -98,6 +98,8 @@ export default function typographyStyles({ theme }) {
           display: 'inline-block',
           fontSize: theme('fontSize.sm')[0],
           fontWeight: theme('fontWeight.semibold'),
+          // Long configuration keys wrap on narrow screens instead of widening the article.
+          overflowWrap: 'anywhere',
           paddingLeft: theme('spacing.1'),
           paddingRight: theme('spacing.1'),
         },
@@ -223,6 +225,7 @@ export default function typographyStyles({ theme }) {
           display: 'inline',
           fontSize: 'inherit',
           fontWeight: 'inherit',
+          overflowWrap: 'normal',
           padding: 0,
         },
         strong: {

--- a/typography.js
+++ b/typography.js
@@ -125,7 +125,13 @@ export default function typographyStyles({ theme }) {
           margin: 0,
         },
         h2: {
-          fontSize: '2.25rem', // 36px — matches design-tokens h2 desktop
+          fontSize: '1.5rem', // 24px → 30px → 36px — matches design-tokens h2
+          '@media (min-width: 640px)': {
+            fontSize: '1.875rem',
+          },
+          '@media (min-width: 1024px)': {
+            fontSize: '2.25rem',
+          },
           lineHeight: '1.2',
           marginBottom: theme('spacing.8'),
           marginTop: theme('spacing.10'),
@@ -137,7 +143,13 @@ export default function typographyStyles({ theme }) {
           color: 'var(--tw-prose-headings)',
         },
         h3: {
-          fontSize: '1.75rem', // 28px — matches design-tokens h3 desktop
+          fontSize: '1.25rem', // 20px → 24px → 28px — matches design-tokens h3
+          '@media (min-width: 640px)': {
+            fontSize: '1.5rem',
+          },
+          '@media (min-width: 1024px)': {
+            fontSize: '1.75rem',
+          },
           lineHeight: '1.3',
           marginBottom: theme('spacing.4'),
           marginTop: theme('spacing.16'),


### PR DESCRIPTION
## Summary
- refine home spacing, responsive composition, and compact navigation targets
- contain article and keybind tables while simplifying mobile pagination
- tighten article reading measure and heading scale, then improve dialog and Uses page rhythm

## Responsive verification
- audited primary pages at 320px, 375px, 768px, and 1280px
- kept page width within the viewport while preserving local table scrolling
- standardized independent interaction targets to at least 44px

## Test plan
- pnpm lint
- pnpm test (120/120)
- pnpm build
- pnpm exec playwright test --reporter=list (132/132)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responsive MDX-rendered tables now support horizontal scrolling on narrow screens.
* **Improvements**
  * Keybind/table layouts now use consistent horizontal scrolling and padding.
  * Reading-width/layout guidance and breakpoints were updated to 72ch, including wider desktop grid/table behavior; responsive typography, pagination, and dialog sizing were adjusted.
* **Accessibility**
  * Navigation, buttons, and header/footer controls received increased minimum sizing for more touch-friendly targets and consistent alignment.
* **Bug Fixes**
  * Reduced horizontal overflow risk and improved wide-content behavior in key layouts.
* **Documentation / Tests**
  * Updated layout guidance and added Playwright home-page overflow, alignment, and touch-target checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->